### PR TITLE
Fix/keycloak sync

### DIFF
--- a/apps/platform/app/api/v1/auth/signup/route.ts
+++ b/apps/platform/app/api/v1/auth/signup/route.ts
@@ -8,6 +8,11 @@ import {
 } from '@/lib/auth';
 import { prisma } from '@governs-ai/db';
 import { syncUserToKeycloak } from '@/lib/keycloak-admin';
+import {
+  enqueueKeycloakSyncJob,
+  recordKeycloakSyncFailure,
+  recordKeycloakSyncSuccess,
+} from '@/lib/keycloak-sync';
 
 const signupSchema = z.object({
   email: z.string().email(),
@@ -93,9 +98,40 @@ export async function POST(request: NextRequest) {
       orgId: org.id,
       orgSlug: org.slug,
       role: 'OWNER',
-    }).catch((error) => {
-      // Log but don't block signup if Keycloak sync fails
-      console.error('Keycloak sync failed during signup:', error);
+    })
+      .then(async (result) => {
+        if (result.success) {
+          await recordKeycloakSyncSuccess(user.id);
+        } else {
+          await recordKeycloakSyncFailure({ userId: user.id, error: result.error });
+          await enqueueKeycloakSyncJob({
+            userId: user.id,
+            email: user.email,
+            name: user.name || undefined,
+            orgId: org.id,
+            orgSlug: org.slug,
+            role: 'OWNER',
+            emailVerified: !!user.emailVerified,
+            password,
+            passwordTtlMs: 15 * 60_000,
+          });
+        }
+      })
+      .catch(async (error) => {
+        // Log but don't block signup if Keycloak sync fails
+        console.error('Keycloak sync failed during signup:', error);
+        await recordKeycloakSyncFailure({ userId: user.id, error });
+        await enqueueKeycloakSyncJob({
+          userId: user.id,
+          email: user.email,
+          name: user.name || undefined,
+          orgId: org.id,
+          orgSlug: org.slug,
+          role: 'OWNER',
+          emailVerified: !!user.emailVerified,
+          password,
+          passwordTtlMs: 15 * 60_000,
+        });
     });
 
     return NextResponse.json({
@@ -119,7 +155,7 @@ export async function POST(request: NextRequest) {
 
     if (error instanceof z.ZodError) {
       return NextResponse.json(
-        { error: 'Invalid input', details: error.errors },
+        { error: 'Invalid input', details: error.issues },
         { status: 400 }
       );
     }

--- a/apps/platform/app/api/v1/sso/keycloak/retry/route.ts
+++ b/apps/platform/app/api/v1/sso/keycloak/retry/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@governs-ai/db';
+import { verifySessionToken } from '@/lib/auth';
+import { syncUserToKeycloak } from '@/lib/keycloak-admin';
+import {
+  enqueueKeycloakSyncJob,
+  recordKeycloakSyncFailure,
+  recordKeycloakSyncSuccess,
+} from '@/lib/keycloak-sync';
+
+const bodySchema = z
+  .object({
+    password: z.string().min(1).optional(),
+  })
+  .optional();
+
+function isPasswordRequiredError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('password not provided for creation');
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionToken = request.cookies.get('session')?.value;
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const session = verifySessionToken(sessionToken);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid session' }, { status: 401 });
+    }
+
+    const body = bodySchema.parse(await request.json().catch(() => ({})));
+    const password = body?.password;
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.sub },
+      select: { id: true, email: true, name: true, emailVerified: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const membership = await prisma.orgMembership.findUnique({
+      where: {
+        orgId_userId: {
+          orgId: session.orgId,
+          userId: user.id,
+        },
+      },
+      include: { org: true },
+    });
+
+    if (!membership) {
+      return NextResponse.json({ error: 'Organization access required' }, { status: 403 });
+    }
+
+    const result = await syncUserToKeycloak({
+      userId: user.id,
+      email: user.email,
+      name: user.name || undefined,
+      password,
+      emailVerified: !!user.emailVerified,
+      orgId: membership.org.id,
+      orgSlug: membership.org.slug,
+      role: membership.role,
+    });
+
+    if (result.success) {
+      await recordKeycloakSyncSuccess(user.id);
+      await prisma.keycloakSyncJob.updateMany({
+        where: {
+          userId: user.id,
+          orgId: membership.org.id,
+          status: { in: ['PENDING', 'FAILED', 'RUNNING'] },
+        },
+        data: { status: 'SUCCEEDED', lastError: null },
+      });
+
+      return NextResponse.json({ success: true });
+    }
+
+    const err = result.error ?? new Error('Keycloak sync failed');
+
+    if (isPasswordRequiredError(err)) {
+      await recordKeycloakSyncFailure({ userId: user.id, error: err });
+      return NextResponse.json({ success: false, requiresPassword: true }, { status: 409 });
+    }
+
+    await recordKeycloakSyncFailure({ userId: user.id, error: err });
+
+    await enqueueKeycloakSyncJob({
+      userId: user.id,
+      email: user.email,
+      name: user.name || undefined,
+      orgId: membership.org.id,
+      orgSlug: membership.org.slug,
+      role: membership.role,
+      emailVerified: !!user.emailVerified,
+      password,
+      passwordTtlMs: 15 * 60_000,
+    });
+
+    return NextResponse.json({ success: false, error: 'SSO sync failed; retry scheduled.' }, { status: 502 });
+  } catch (error) {
+    console.error('Keycloak retry error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/app/api/v1/sso/keycloak/worker/route.ts
+++ b/apps/platform/app/api/v1/sso/keycloak/worker/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { processKeycloakSyncJobs } from '@/lib/keycloak-sync';
+
+// Simple bearer-token protection for cron/worker execution
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.KEYCLOAK_SYNC_WORKER_TOKEN;
+  if (!expected) return false;
+
+  const auth = request.headers.get('authorization') || '';
+  return auth === `Bearer ${expected}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await processKeycloakSyncJobs({ limit: 50 });
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error('Keycloak sync worker endpoint failed:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/components/keycloak-sso-banner.tsx
+++ b/apps/platform/components/keycloak-sso-banner.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@governs-ai/ui';
+import { useUser } from '@/lib/user-context';
+
+export function KeycloakSsoBanner() {
+  const { user, loading, refetch } = useUser();
+  const sync = user?.keycloakSync;
+
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [needsPassword, setNeedsPassword] = React.useState(false);
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  if (loading) return null;
+  if (!sync || sync.status !== 'DEGRADED') return null;
+
+  const nextRetry = sync.nextRetryAt ? new Date(sync.nextRetryAt) : null;
+
+  const runRetry = async (maybePassword?: string) => {
+    try {
+      setIsSubmitting(true);
+      setError(null);
+
+      const res = await fetch('/api/v1/sso/keycloak/retry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(maybePassword ? { password: maybePassword } : {}),
+      });
+
+      const data = await res.json().catch(() => ({} as any));
+
+      if (data?.requiresPassword) {
+        setNeedsPassword(true);
+        return;
+      }
+
+      if (!res.ok) {
+        setError(data?.error || 'Retry failed');
+        return;
+      }
+
+      setNeedsPassword(false);
+      setPassword('');
+      await refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Retry failed');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-950">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="font-medium">SSO not ready — retrying</div>
+          <div className="text-sm text-amber-900">
+            External “Login with GovernsAI” may not work until Keycloak sync completes.
+            {nextRetry ? (
+              <span className="ml-2">
+                Next automatic retry: <span className="font-mono">{nextRetry.toLocaleString()}</span>
+              </span>
+            ) : null}
+          </div>
+          {sync.lastError ? (
+            <details className="mt-2 text-xs">
+              <summary className="cursor-pointer select-none">Show last error</summary>
+              <pre className="mt-2 overflow-auto rounded bg-white/60 p-2">{sync.lastError}</pre>
+            </details>
+          ) : null}
+          {error ? <div className="mt-2 text-sm text-red-700">{error}</div> : null}
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 md:flex-row md:items-center">
+          {needsPassword ? (
+            <input
+              className="h-9 w-full rounded border border-amber-300 bg-white px-3 text-sm outline-none md:w-56"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter password to retry"
+            />
+          ) : null}
+
+          <Button
+            variant="secondary"
+            className="h-9"
+            disabled={isSubmitting || (needsPassword && password.length === 0)}
+            onClick={() => runRetry(needsPassword ? password : undefined)}
+          >
+            {isSubmitting ? 'Retrying…' : 'Retry Keycloak sync'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/components/platform-shell.tsx
+++ b/apps/platform/components/platform-shell.tsx
@@ -22,6 +22,7 @@ import {
   CreditCard
 } from 'lucide-react';
 import { useUser } from '@/lib/user-context';
+import { KeycloakSsoBanner } from '@/components/keycloak-sso-banner';
 
 interface PlatformShellProps {
   children: React.ReactNode;
@@ -288,6 +289,7 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
 
         {/* Main content area */}
         <main className="p-6">
+          <KeycloakSsoBanner />
           {children}
         </main>
       </div>

--- a/apps/platform/lib/keycloak-sync.ts
+++ b/apps/platform/lib/keycloak-sync.ts
@@ -1,0 +1,354 @@
+import 'server-only';
+
+import { prisma } from '@governs-ai/db';
+import { syncUserToKeycloak, type SyncUserToKeycloakParams } from './keycloak-admin';
+import crypto from 'crypto';
+
+const DEFAULT_MAX_ATTEMPTS = 10;
+
+function now() {
+  return new Date();
+}
+
+function serializeError(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}${err.stack ? `\n${err.stack}` : ''}`;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function computeBackoffMs(attempts: number): number {
+  // 30s, 60s, 120s, ... capped at 30m
+  const base = 30_000;
+  const cap = 30 * 60_000;
+  const exp = Math.min(attempts, 10);
+  return Math.min(base * 2 ** exp, cap);
+}
+
+function getPasswordEncryptionKey(): Buffer | null {
+  const raw = process.env.KEYCLOAK_SYNC_PASSWORD_ENCRYPTION_KEY;
+  if (!raw) return null;
+
+  // Expect base64 32 bytes (AES-256)
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== 32) {
+    console.warn(
+      'KEYCLOAK_SYNC_PASSWORD_ENCRYPTION_KEY must be 32 bytes (base64). Password retries disabled.'
+    );
+    return null;
+  }
+
+  return key;
+}
+
+function encryptPassword(plaintext: string): Buffer | null {
+  const key = getPasswordEncryptionKey();
+  if (!key) return null;
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  // iv (12) + tag (16) + ciphertext
+  return Buffer.concat([iv, tag, ciphertext]);
+}
+
+function decryptPassword(payload: Buffer): string | null {
+  const key = getPasswordEncryptionKey();
+  if (!key) return null;
+  if (payload.length < 12 + 16 + 1) return null;
+
+  const iv = payload.subarray(0, 12);
+  const tag = payload.subarray(12, 28);
+  const ciphertext = payload.subarray(28);
+
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}
+
+function isPasswordRequiredError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('password not provided for creation');
+}
+
+export async function recordKeycloakSyncSuccess(userId: string): Promise<void> {
+  await prisma.keycloakSyncState.upsert({
+    where: { userId },
+    create: {
+      userId,
+      status: 'HEALTHY',
+      lastSyncedAt: now(),
+      lastAttemptAt: now(),
+      retryCount: 0,
+      nextRetryAt: null,
+      lastError: null,
+    },
+    update: {
+      status: 'HEALTHY',
+      lastSyncedAt: now(),
+      lastAttemptAt: now(),
+      retryCount: 0,
+      nextRetryAt: null,
+      lastError: null,
+    },
+  });
+}
+
+export async function recordKeycloakSyncFailure(params: {
+  userId: string;
+  error: unknown;
+  nextRetryAt?: Date | null;
+}): Promise<void> {
+  const { userId, error, nextRetryAt } = params;
+
+  await prisma.keycloakSyncState.upsert({
+    where: { userId },
+    create: {
+      userId,
+      status: 'DEGRADED',
+      lastSyncedAt: null,
+      lastAttemptAt: now(),
+      retryCount: 1,
+      nextRetryAt: nextRetryAt ?? null,
+      lastError: serializeError(error),
+    },
+    update: {
+      status: 'DEGRADED',
+      lastAttemptAt: now(),
+      retryCount: { increment: 1 },
+      nextRetryAt: nextRetryAt ?? null,
+      lastError: serializeError(error),
+    },
+  });
+}
+
+export async function enqueueKeycloakSyncJob(params: {
+  userId: string;
+  email: string;
+  name?: string;
+  orgId: string;
+  orgSlug: string;
+  role: 'OWNER' | 'ADMIN' | 'DEVELOPER' | 'VIEWER';
+  emailVerified: boolean;
+  password?: string;
+  // If provided, encrypted password will only be kept for this long.
+  passwordTtlMs?: number;
+}): Promise<void> {
+  const passwordTtlMs = params.passwordTtlMs ?? 15 * 60_000; // 15 minutes
+
+  const encryptedPassword = params.password
+    ? encryptPassword(params.password)
+    : null;
+
+  const passwordExpiresAt =
+    encryptedPassword && params.password ? new Date(Date.now() + passwordTtlMs) : null;
+
+  const existing = await prisma.keycloakSyncJob.findFirst({
+    where: {
+      userId: params.userId,
+      orgId: params.orgId,
+      status: { in: ['PENDING', 'FAILED'] },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  if (existing) {
+    await prisma.keycloakSyncJob.update({
+      where: { id: existing.id },
+      data: {
+        email: params.email,
+        name: params.name ?? null,
+        orgSlug: params.orgSlug,
+        role: params.role,
+        emailVerified: params.emailVerified,
+        encryptedPassword: encryptedPassword ?? undefined,
+        passwordExpiresAt: passwordExpiresAt ?? undefined,
+        status: 'PENDING',
+        nextRunAt: now(),
+      },
+    });
+    await prisma.keycloakSyncState.upsert({
+      where: { userId: params.userId },
+      create: {
+        userId: params.userId,
+        status: 'DEGRADED',
+        lastSyncedAt: null,
+        lastAttemptAt: now(),
+        retryCount: 0,
+        nextRetryAt: now(),
+        lastError: null,
+      },
+      update: {
+        status: 'DEGRADED',
+        nextRetryAt: now(),
+      },
+    });
+    return;
+  }
+
+  await prisma.keycloakSyncJob.create({
+    data: {
+      userId: params.userId,
+      email: params.email,
+      name: params.name ?? null,
+      orgId: params.orgId,
+      orgSlug: params.orgSlug,
+      role: params.role,
+      emailVerified: params.emailVerified,
+      encryptedPassword: encryptedPassword ?? undefined,
+      passwordExpiresAt: passwordExpiresAt ?? undefined,
+      status: 'PENDING',
+      nextRunAt: now(),
+    },
+  });
+
+  await prisma.keycloakSyncState.upsert({
+    where: { userId: params.userId },
+    create: {
+      userId: params.userId,
+      status: 'DEGRADED',
+      lastSyncedAt: null,
+      lastAttemptAt: now(),
+      retryCount: 0,
+      nextRetryAt: now(),
+      lastError: null,
+    },
+    update: {
+      status: 'DEGRADED',
+      nextRetryAt: now(),
+    },
+  });
+}
+
+export async function processKeycloakSyncJobs(params?: { limit?: number }): Promise<{
+  processed: number;
+  succeeded: number;
+  failed: number;
+}> {
+  const limit = params?.limit ?? 25;
+  const due = await prisma.keycloakSyncJob.findMany({
+    where: {
+      status: { in: ['PENDING', 'FAILED'] },
+      nextRunAt: { lte: now() },
+      attempts: { lt: DEFAULT_MAX_ATTEMPTS },
+    },
+    orderBy: { nextRunAt: 'asc' },
+    take: limit,
+  });
+
+  let processed = 0;
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const job of due) {
+    // Claim the job (best-effort; avoids concurrent workers double-processing)
+    const claim = await prisma.keycloakSyncJob.updateMany({
+      where: { id: job.id, status: { in: ['PENDING', 'FAILED'] } },
+      data: { status: 'RUNNING', lastAttemptAt: now() },
+    });
+
+    if (claim.count === 0) continue;
+
+    processed++;
+
+    let password: string | undefined;
+    if (job.encryptedPassword && job.passwordExpiresAt && job.passwordExpiresAt > now()) {
+      const decrypted = decryptPassword(job.encryptedPassword);
+      if (decrypted) password = decrypted;
+    }
+
+    const syncParams: SyncUserToKeycloakParams = {
+      userId: job.userId,
+      email: job.email,
+      name: job.name ?? undefined,
+      password,
+      emailVerified: job.emailVerified,
+      orgId: job.orgId,
+      orgSlug: job.orgSlug,
+      role: job.role,
+    };
+
+    const result = await syncUserToKeycloak(syncParams);
+
+    if (result.success) {
+      succeeded++;
+      await prisma.$transaction([
+        prisma.keycloakSyncJob.update({
+          where: { id: job.id },
+          data: { status: 'SUCCEEDED', lastError: null },
+        }),
+        prisma.keycloakSyncState.upsert({
+          where: { userId: job.userId },
+          create: {
+            userId: job.userId,
+            status: 'HEALTHY',
+            lastSyncedAt: now(),
+            lastAttemptAt: now(),
+            retryCount: 0,
+            nextRetryAt: null,
+            lastError: null,
+          },
+          update: {
+            status: 'HEALTHY',
+            lastSyncedAt: now(),
+            lastAttemptAt: now(),
+            retryCount: 0,
+            nextRetryAt: null,
+            lastError: null,
+          },
+        }),
+      ]);
+      continue;
+    }
+
+    failed++;
+
+    const err = result.error ?? new Error('Keycloak sync failed');
+    const requiresPassword = isPasswordRequiredError(err);
+
+    const nextRunAt = requiresPassword
+      ? null
+      : new Date(Date.now() + computeBackoffMs(job.attempts));
+
+    await prisma.$transaction([
+      prisma.keycloakSyncJob.update({
+        where: { id: job.id },
+        data: {
+          status: 'FAILED',
+          attempts: { increment: 1 },
+          lastError: serializeError(err),
+          nextRunAt: nextRunAt ?? new Date('9999-12-31T00:00:00.000Z'),
+        },
+      }),
+      prisma.keycloakSyncState.upsert({
+        where: { userId: job.userId },
+        create: {
+          userId: job.userId,
+          status: 'DEGRADED',
+          lastSyncedAt: null,
+          lastAttemptAt: now(),
+          retryCount: 1,
+          nextRetryAt: nextRunAt,
+          lastError: serializeError(err),
+        },
+        update: {
+          status: 'DEGRADED',
+          lastAttemptAt: now(),
+          retryCount: { increment: 1 },
+          nextRetryAt: nextRunAt,
+          lastError: serializeError(err),
+        },
+      }),
+    ]);
+  }
+
+  return { processed, succeeded, failed };
+}

--- a/apps/platform/lib/user-context.tsx
+++ b/apps/platform/lib/user-context.tsx
@@ -8,6 +8,13 @@ interface User {
   name: string | null;
   emailVerified: Date | null;
   createdAt: Date;
+  keycloakSync?: {
+    status: 'HEALTHY' | 'DEGRADED';
+    lastSyncedAt?: string | null;
+    lastAttemptAt?: string | null;
+    nextRetryAt?: string | null;
+    lastError?: string | null;
+  };
 }
 
 interface Organization {

--- a/apps/platform/scripts/keycloak-sync-worker.ts
+++ b/apps/platform/scripts/keycloak-sync-worker.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env tsx
+
+import { processKeycloakSyncJobs } from '../lib/keycloak-sync';
+
+async function main() {
+  const result = await processKeycloakSyncJobs({ limit: 50 });
+  console.log('Keycloak sync worker result:', result);
+}
+
+main().catch((err) => {
+  console.error('Keycloak sync worker failed:', err);
+  process.exit(1);
+});

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -36,6 +36,14 @@ KEYCLOAK_REALM="governs-ai"
 KEYCLOAK_ADMIN_CLIENT_ID="admin-sync-client"
 KEYCLOAK_ADMIN_CLIENT_SECRET="your-admin-client-secret"
 
+# Optional: enables durable retries for Keycloak *creation* flows by storing
+# a short-lived encrypted copy of the signup password in the DB retry queue.
+# Must be base64-encoded 32 bytes (AES-256 key).
+KEYCLOAK_SYNC_PASSWORD_ENCRYPTION_KEY="base64-32-bytes"
+
+# Optional: protects the Keycloak sync worker endpoint (cron).
+KEYCLOAK_SYNC_WORKER_TOKEN="strong-random-token"
+
 # Legacy / alternative settings (not used by current dashboard sync code):
 # KEYCLOAK_ADMIN_URL="http://localhost:8080"
 # KEYCLOAK_ADMIN_USERNAME="admin"

--- a/docs/keycloak-integration.md
+++ b/docs/keycloak-integration.md
@@ -573,6 +573,15 @@ All sync operations log to the application console:
 ⚠️  Keycloak user not found for email: user@example.com
 ```
 
+### Durable retries (recommended)
+
+Keycloak can be temporarily unavailable. The dashboard keeps user signup/login working and will surface an **SSO not ready** banner when sync is degraded.
+
+For durable retries, the platform maintains a DB-backed retry queue and can be driven by:
+
+- A cron calling `POST /api/v1/sso/keycloak/worker` with `Authorization: Bearer $KEYCLOAK_SYNC_WORKER_TOKEN`
+- Or a one-off local run: `npx tsx apps/platform/scripts/keycloak-sync-worker.ts`
+
 ## Additional Resources
 
 - [Keycloak Admin REST API Documentation](https://www.keycloak.org/docs-api/latest/rest-api/)

--- a/packages/db/migrations/20251212185207_/migration.sql
+++ b/packages/db/migrations/20251212185207_/migration.sql
@@ -1,0 +1,68 @@
+-- CreateEnum
+CREATE TYPE "KeycloakSyncStatus" AS ENUM ('HEALTHY', 'DEGRADED');
+
+-- CreateEnum
+CREATE TYPE "KeycloakSyncJobStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "keycloak_sync_state" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "status" "KeycloakSyncStatus" NOT NULL DEFAULT 'DEGRADED',
+    "last_synced_at" TIMESTAMP(3),
+    "last_attempt_at" TIMESTAMP(3),
+    "retry_count" INTEGER NOT NULL DEFAULT 0,
+    "next_retry_at" TIMESTAMP(3),
+    "last_error" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "keycloak_sync_state_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "keycloak_sync_jobs" (
+    "id" TEXT NOT NULL,
+    "status" "KeycloakSyncJobStatus" NOT NULL DEFAULT 'PENDING',
+    "user_id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "org_id" TEXT NOT NULL,
+    "org_slug" TEXT NOT NULL,
+    "role" "OrgRole" NOT NULL,
+    "email_verified" BOOLEAN NOT NULL DEFAULT false,
+    "encrypted_password" BYTEA,
+    "password_expires_at" TIMESTAMP(3),
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "next_run_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_error" TEXT,
+    "last_attempt_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "keycloak_sync_jobs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "keycloak_sync_state_user_id_key" ON "keycloak_sync_state"("user_id");
+
+-- CreateIndex
+CREATE INDEX "keycloak_sync_state_status_idx" ON "keycloak_sync_state"("status");
+
+-- CreateIndex
+CREATE INDEX "keycloak_sync_state_next_retry_at_idx" ON "keycloak_sync_state"("next_retry_at");
+
+-- CreateIndex
+CREATE INDEX "keycloak_sync_jobs_status_next_run_at_idx" ON "keycloak_sync_jobs"("status", "next_run_at");
+
+-- CreateIndex
+CREATE INDEX "keycloak_sync_jobs_user_id_org_id_idx" ON "keycloak_sync_jobs"("user_id", "org_id");
+
+-- AddForeignKey
+ALTER TABLE "keycloak_sync_state" ADD CONSTRAINT "keycloak_sync_state_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "keycloak_sync_jobs" ADD CONSTRAINT "keycloak_sync_jobs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "keycloak_sync_jobs" ADD CONSTRAINT "keycloak_sync_jobs_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -35,6 +35,7 @@ model Org {
   conversations        Conversation[]
   contextAccessLog     ContextAccessLog[]
   documents            Document[]
+  keycloakSyncJobs     KeycloakSyncJob[]
 }
 
 model User {
@@ -63,6 +64,8 @@ model User {
   conversations        Conversation[]
   contextAccessLog     ContextAccessLog[]
   documents            Document[]
+  keycloakSyncState    KeycloakSyncState?
+  keycloakSyncJobs     KeycloakSyncJob[]
 }
 
 model Credential {
@@ -715,4 +718,70 @@ enum OrgRole {
   ADMIN
   DEVELOPER
   VIEWER
+}
+
+// ---------------------------------------------
+// Keycloak sync state + durable retry queue
+// ---------------------------------------------
+
+enum KeycloakSyncStatus {
+  HEALTHY        // last sync succeeded
+  DEGRADED       // last sync failed (retryable) or pending
+}
+
+enum KeycloakSyncJobStatus {
+  PENDING
+  RUNNING
+  SUCCEEDED
+  FAILED
+}
+
+model KeycloakSyncState {
+  id            String            @id @default(cuid())
+  userId        String            @unique @map("user_id")
+  status        KeycloakSyncStatus @default(DEGRADED)
+  lastSyncedAt  DateTime?         @map("last_synced_at")
+  lastAttemptAt DateTime?         @map("last_attempt_at")
+  retryCount    Int               @default(0) @map("retry_count")
+  nextRetryAt   DateTime?         @map("next_retry_at")
+  lastError     String?           @db.Text @map("last_error")
+  updatedAt     DateTime          @updatedAt @map("updated_at")
+  createdAt     DateTime          @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([status])
+  @@index([nextRetryAt])
+  @@map("keycloak_sync_state")
+}
+
+model KeycloakSyncJob {
+  id        String              @id @default(cuid())
+  status    KeycloakSyncJobStatus @default(PENDING)
+  userId    String              @map("user_id")
+  email     String
+  name      String?
+  orgId     String              @map("org_id")
+  orgSlug   String              @map("org_slug")
+  role      OrgRole
+  emailVerified Boolean         @default(false) @map("email_verified")
+
+  // Optional encrypted password for short-lived retry of *creation* flows.
+  // NOTE: plaintext is never stored; encryption is application-level.
+  encryptedPassword Bytes?      @map("encrypted_password")
+  passwordExpiresAt DateTime?   @map("password_expires_at")
+
+  attempts     Int              @default(0)
+  nextRunAt    DateTime         @default(now()) @map("next_run_at")
+  lastError    String?          @db.Text @map("last_error")
+  lastAttemptAt DateTime?       @map("last_attempt_at")
+  createdAt    DateTime         @default(now()) @map("created_at")
+  updatedAt    DateTime         @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  org  Org  @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([status, nextRunAt])
+  @@index([userId, orgId])
+  @@map("keycloak_sync_jobs")
 }


### PR DESCRIPTION
**Signup/login never blocked by Keycloak**
- All Keycloak sync calls remain non-blocking; failures are recorded + queued.

**Explicit SSO status (DB-backed)**
- Added Prisma models:
  - KeycloakSyncState (per-user status: HEALTHY / DEGRADED)
  - KeycloakSyncJob (durable retry queue)
- Migration created: packages/db/migrations/20251212185207_

**Banner in the dashboard**
- New client banner: `apps/platform/components/keycloak-sso-banner.tsx`
- Rendered globally in `apps/platform/components/platform-shell.tsx`
- Shows “SSO not ready — retrying”, last error (expandable), and next retry time.

**Retry button + password only when needed**
- New internal endpoint: `POST /api/v1/sso/keycloak/retry`
  - Tries without password first
  - If Keycloak user doesn’t exist, returns requiresPassword: true and UI prompts for password
  - On success marks sync healthy + closes pending jobs

**Durable retries (job queue + worker)**
- Failures enqueue retry jobs via apps/platform/lib/keycloak-sync.ts
- **Worker options:**
  - Cron/worker endpoint: `POST /api/v1/sso/keycloak/worker protected by Authorization: Bearer $KEYCLOAK_SYNC_WORKER_TOKEN`
  - Local script: `apps/platform/scripts/keycloak-sync-worker.ts`

**No “partial Keycloak users”**
- syncUserToKeycloak now rolls back (deletes) the Keycloak user if password setting fails after creation.
