### PR TITLE
fix: TypeScript build fixes, Websocket Dockerfile, API key precheck sync

### DIFF
--- a/apps/platform/app/api/v1/keys/route.ts
+++ b/apps/platform/app/api/v1/keys/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@governs-ai/db';
 import { randomBytes } from 'crypto';
 import { requireAuth } from '@/lib/session';
+import { syncKeyToPrecheck } from '@/lib/precheck-key-sync';
 
 export async function GET(request: NextRequest) {
   try {
@@ -57,6 +58,9 @@ export async function POST(request: NextRequest) {
         isActive: true,
       },
     });
+
+    syncKeyToPrecheck(keyValue, userId)
+      .catch(err => console.error('[api-keys] precheck sync failed (non-fatal):', err));
 
     // Return the key value only once for security
     return NextResponse.json({

--- a/apps/platform/app/api/v1/orgs/[orgId]/api-keys/[keyId]/route.ts
+++ b/apps/platform/app/api/v1/orgs/[orgId]/api-keys/[keyId]/route.ts
@@ -4,6 +4,7 @@ import { verifySessionToken } from '@/lib/auth';
 import { prisma } from '@governs-ai/db';
 import { randomBytes } from 'crypto';
 import { Prisma } from '@prisma/client';
+import { syncKeyToPrecheck, deactivateKeyInPrecheck } from '@/lib/precheck-key-sync';
 
 const updateKeySchema = z.object({
   name: z.string().min(1).optional(),
@@ -348,11 +349,14 @@ export async function DELETE(
     // Revoke the key (mark as inactive)
     await prisma.aPIKey.update({
       where: { id: keyId },
-      data: { 
+      data: {
         isActive: false,
         updatedAt: new Date(),
       },
     });
+
+    deactivateKeyInPrecheck(existingKey.key)
+      .catch(err => console.error('[api-keys] precheck deactivate failed (non-fatal):', err));
 
     // If disconnect=true, close active WebSocket sessions
     if (disconnect) {
@@ -465,6 +469,12 @@ export async function POST(
 
     // Generate new API key
     const newKeyValue = `gov_key_${randomBytes(32).toString('hex')}`;
+
+    // Deactivate old key in precheck, register new one
+    deactivateKeyInPrecheck(existingKey.key)
+      .catch(err => console.error('[api-keys] precheck old-key deactivate failed (non-fatal):', err));
+    syncKeyToPrecheck(newKeyValue, session.sub, existingKey.expiresAt)
+      .catch(err => console.error('[api-keys] precheck new-key sync failed (non-fatal):', err));
 
     // Update the key with new value
     const rotatedKey = await prisma.aPIKey.update({

--- a/apps/platform/app/api/v1/orgs/[orgId]/api-keys/route.ts
+++ b/apps/platform/app/api/v1/orgs/[orgId]/api-keys/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { verifySessionToken } from '@/lib/auth';
 import { prisma } from '@governs-ai/db';
 import { randomBytes } from 'crypto';
+import { syncKeyToPrecheck } from '@/lib/precheck-key-sync';
 
 const createKeySchema = z.object({
   name: z.string().min(1),
@@ -247,6 +248,10 @@ export async function POST(
         },
       },
     });
+
+    // Sync key to precheck's api_keys table so precheck can validate it
+    syncKeyToPrecheck(keyValue, session.sub, expiresAt ? new Date(expiresAt) : null)
+      .catch(err => console.error('[api-keys] precheck sync failed (non-fatal):', err));
 
     return NextResponse.json({
       success: true,

--- a/apps/platform/lib/precheck-key-sync.ts
+++ b/apps/platform/lib/precheck-key-sync.ts
@@ -1,0 +1,44 @@
+import 'server-only';
+import { createHmac } from 'crypto';
+import { prisma } from '@governs-ai/db';
+
+function hmacKey(rawKey: string): string {
+  const secret = process.env.KEY_HMAC_SECRET;
+  if (!secret) return '';
+  return createHmac('sha256', secret).update(rawKey).digest('hex');
+}
+
+/**
+ * Insert or reactivate a key in precheck's api_keys table.
+ * No-op if KEY_HMAC_SECRET is not set (local dev without precheck).
+ */
+export async function syncKeyToPrecheck(
+  rawKey: string,
+  userId: string,
+  expiresAt?: Date | null
+): Promise<void> {
+  if (!process.env.KEY_HMAC_SECRET) {
+    console.warn('[precheck-sync] KEY_HMAC_SECRET not set — skipping api_keys sync');
+    return;
+  }
+  const keyHash = hmacKey(rawKey);
+  const keyPrefix = rawKey.slice(0, 8);
+  await prisma.$executeRaw`
+    INSERT INTO api_keys (key_hash, key_prefix, user_id, created_at, is_active, expires_at)
+    VALUES (${keyHash}, ${keyPrefix}, ${userId}, NOW(), true, ${expiresAt ?? null})
+    ON CONFLICT (key_hash) DO UPDATE
+      SET is_active = true, expires_at = EXCLUDED.expires_at
+  `;
+}
+
+/**
+ * Deactivate a key in precheck's api_keys table.
+ * No-op if KEY_HMAC_SECRET is not set.
+ */
+export async function deactivateKeyInPrecheck(rawKey: string): Promise<void> {
+  if (!process.env.KEY_HMAC_SECRET) return;
+  const keyHash = hmacKey(rawKey);
+  await prisma.$executeRaw`
+    UPDATE api_keys SET is_active = false WHERE key_hash = ${keyHash}
+  `;
+}

--- a/apps/websocket-service/Dockerfile
+++ b/apps/websocket-service/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-slim AS base
+
+RUN npm install -g pnpm@10.12.4
+WORKDIR /app
+
+# Copy workspace manifests only (for layer caching)
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/db/package.json ./packages/db/
+COPY apps/websocket-service/package.json ./apps/websocket-service/
+
+# Install all workspace deps
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/db/ ./packages/db/
+COPY apps/websocket-service/ ./apps/websocket-service/
+
+# Generate Prisma client
+RUN pnpm --filter @governs-ai/db generate
+
+WORKDIR /app/apps/websocket-service
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+EXPOSE 3001
+
+# Use node directly — env vars come from Render, not a .env file
+CMD ["node", "src/server.js"]


### PR DESCRIPTION
## Summary

- **Next.js 15 async params**: All dynamic route handlers updated to `await params` — was crashing Vercel builds
- **ZodError API**: `.errors` → `.issues` across 13 routes  
- **Websocket Dockerfile**: Monorepo-aware build from root context for Render deployment
- **Security fixes**: CORS, JWT algorithm pinning, unauthenticated endpoint guard  
- **API key precheck sync**: Keys created in platform now write to precheck's `api_keys` table via HMAC sync — this was the root cause of `API key is required` errors in the chat SDK

## Critical: new env var required

Both platform (Vercel) and precheck (Render) must share the same `KEY_HMAC_SECRET`:

```
# Vercel: platform environment variables
KEY_HMAC_SECRET=<generate: openssl rand -hex 32>

# Render: precheck environment variables  
KEY_HMAC_SECRET=<same value>
```

## Test plan
- [ ] Vercel build passes for `@governs-ai/platform`
- [ ] Create API key in platform dashboard → use it in chat SDK → precheck accepts it
- [ ] Websocket service deploys on Render from Dockerfile