### PR TITLE
feat(api-keys): pass org_id to precheck when syncing keys (DL-2)

### DIFF
--- a/apps/platform/__mocks__/server-only.ts
+++ b/apps/platform/__mocks__/server-only.ts
@@ -1,0 +1,2 @@
+// Stub for the `server-only` package so lib modules can be imported in jest.
+export {};

--- a/apps/platform/__tests__/lib/precheck-key-sync.test.ts
+++ b/apps/platform/__tests__/lib/precheck-key-sync.test.ts
@@ -1,0 +1,60 @@
+/**
+ * DL-2 — syncKeyToPrecheck must pass org_id into the precheck api_keys row.
+ */
+
+// KEY_HMAC_SECRET must be set before the module is imported — the function checks it
+// at call time (not import time), but the test also needs to exercise the unset path.
+process.env.KEY_HMAC_SECRET = 'test-hmac-secret';
+
+import { prisma } from '@governs-ai/db';
+import { syncKeyToPrecheck } from '@/lib/precheck-key-sync';
+
+const mockPrisma = prisma as unknown as { $executeRaw: jest.Mock };
+
+describe('syncKeyToPrecheck', () => {
+  const ORIGINAL_SECRET = process.env.KEY_HMAC_SECRET;
+
+  beforeEach(() => {
+    process.env.KEY_HMAC_SECRET = 'test-hmac-secret';
+    mockPrisma.$executeRaw = jest.fn().mockResolvedValue(1);
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) delete process.env.KEY_HMAC_SECRET;
+    else process.env.KEY_HMAC_SECRET = ORIGINAL_SECRET;
+  });
+
+  it('passes org_id into the raw INSERT values', async () => {
+    await syncKeyToPrecheck('gov_key_rawvalue', 'user-123', 'org-abc');
+
+    expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+    const call = mockPrisma.$executeRaw.mock.calls[0];
+    // Tagged-template args: call[0] is the strings array, call[1..n] are the interpolated values.
+    const [strings, ...values] = call;
+    const sql = (strings as TemplateStringsArray).join('?');
+
+    expect(sql).toMatch(/INSERT INTO api_keys \([^)]*\borg_id\b[^)]*\)/);
+    expect(sql).toMatch(/VALUES \(/);
+    expect(sql).toMatch(/ON CONFLICT \(key_hash\) DO UPDATE/);
+    expect(sql).toMatch(/org_id\s*=\s*EXCLUDED\.org_id/);
+
+    expect(values).toContain('org-abc');
+    expect(values).toContain('user-123');
+  });
+
+  it('forwards expiresAt alongside org_id', async () => {
+    const exp = new Date('2030-01-01T00:00:00.000Z');
+    await syncKeyToPrecheck('gov_key_rawvalue', 'user-1', 'org-1', exp);
+
+    const [, ...values] = mockPrisma.$executeRaw.mock.calls[0];
+    expect(values).toContain('org-1');
+    expect(values).toContain(exp);
+  });
+
+  it('skips the insert when KEY_HMAC_SECRET is unset', async () => {
+    delete process.env.KEY_HMAC_SECRET;
+    await syncKeyToPrecheck('gov_key_rawvalue', 'user-1', 'org-1');
+
+    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+  });
+});

--- a/apps/platform/app/api/v1/keys/route.ts
+++ b/apps/platform/app/api/v1/keys/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    syncKeyToPrecheck(keyValue, userId)
+    syncKeyToPrecheck(keyValue, userId, orgId)
       .catch(err => console.error('[api-keys] precheck sync failed (non-fatal):', err));
 
     // Return the key value only once for security

--- a/apps/platform/app/api/v1/orgs/[orgId]/api-keys/[keyId]/route.ts
+++ b/apps/platform/app/api/v1/orgs/[orgId]/api-keys/[keyId]/route.ts
@@ -473,7 +473,7 @@ export async function POST(
     // Deactivate old key in precheck, register new one
     deactivateKeyInPrecheck(existingKey.key)
       .catch(err => console.error('[api-keys] precheck old-key deactivate failed (non-fatal):', err));
-    syncKeyToPrecheck(newKeyValue, session.sub, existingKey.expiresAt)
+    syncKeyToPrecheck(newKeyValue, session.sub, org.id, existingKey.expiresAt)
       .catch(err => console.error('[api-keys] precheck new-key sync failed (non-fatal):', err));
 
     // Update the key with new value

--- a/apps/platform/app/api/v1/orgs/[orgId]/api-keys/route.ts
+++ b/apps/platform/app/api/v1/orgs/[orgId]/api-keys/route.ts
@@ -250,7 +250,7 @@ export async function POST(
     });
 
     // Sync key to precheck's api_keys table so precheck can validate it
-    syncKeyToPrecheck(keyValue, session.sub, expiresAt ? new Date(expiresAt) : null)
+    syncKeyToPrecheck(keyValue, session.sub, org.id, expiresAt ? new Date(expiresAt) : null)
       .catch(err => console.error('[api-keys] precheck sync failed (non-fatal):', err));
 
     return NextResponse.json({

--- a/apps/platform/jest.config.ts
+++ b/apps/platform/jest.config.ts
@@ -11,6 +11,8 @@ const config: Config = {
     // Replace workspace db package with a hand-written mock
     '^@governs-ai/db$': '<rootDir>/__mocks__/prisma.ts',
     '^@governs-ai/(.*)$': '<rootDir>/__mocks__/governs-ai/$1.ts',
+    // `server-only` throws when loaded outside RSC — stub it in tests
+    '^server-only$': '<rootDir>/__mocks__/server-only.ts',
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {

--- a/apps/platform/lib/precheck-key-sync.ts
+++ b/apps/platform/lib/precheck-key-sync.ts
@@ -15,6 +15,7 @@ function hmacKey(rawKey: string): string {
 export async function syncKeyToPrecheck(
   rawKey: string,
   userId: string,
+  orgId: string,
   expiresAt?: Date | null
 ): Promise<void> {
   if (!process.env.KEY_HMAC_SECRET) {
@@ -24,10 +25,10 @@ export async function syncKeyToPrecheck(
   const keyHash = hmacKey(rawKey);
   const keyPrefix = rawKey.slice(0, 8);
   await prisma.$executeRaw`
-    INSERT INTO api_keys (key_hash, key_prefix, user_id, created_at, is_active, expires_at)
-    VALUES (${keyHash}, ${keyPrefix}, ${userId}, NOW(), true, ${expiresAt ?? null})
+    INSERT INTO api_keys (key_hash, key_prefix, user_id, org_id, created_at, is_active, expires_at)
+    VALUES (${keyHash}, ${keyPrefix}, ${userId}, ${orgId}, NOW(), true, ${expiresAt ?? null})
     ON CONFLICT (key_hash) DO UPDATE
-      SET is_active = true, expires_at = EXCLUDED.expires_at
+      SET is_active = true, expires_at = EXCLUDED.expires_at, org_id = EXCLUDED.org_id
   `;
 }
 


### PR DESCRIPTION
## Summary
- `syncKeyToPrecheck()` now takes `orgId` and writes it into `precheck.api_keys` so precheck can route decisions to the correct org.
- All three callers forward `org.id`: console `/api/v1/keys` POST, `/api/v1/orgs/[orgId]/api-keys` POST, and the rotate path in `/api/v1/orgs/[orgId]/api-keys/[keyId]` POST.
- Raw `INSERT` adds the `org_id` column; `ON CONFLICT (key_hash) DO UPDATE` also refreshes `org_id = EXCLUDED.org_id` so reactivated keys land in the right org.
- New jest suite `__tests__/lib/precheck-key-sync.test.ts` locks in the contract (org_id forwarded, expiresAt forwarded, no-op when `KEY_HMAC_SECRET` unset). Added a `server-only` stub to `__mocks__` so lib files can be imported in jest.

## GovernsAI Tracker issue
GOV-12 (c6716d94-a89c-4fe0-a649-337a4e41cbee)

## Depends on
DL-1 / GOV-11 — precheck `api_keys` table must have the `org_id` column before this can be deployed.

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] `npx jest __tests__/lib/precheck-key-sync.test.ts` — 3/3 pass
- [x] `npx jest` (full suite) — 48/48 pass across 5 suites
- [x] `npx tsc --noEmit` — clean
- [ ] Post-DL-1 smoke: create a key via `/api/v1/orgs/:orgId/api-keys`, verify `api_keys.org_id` populated in precheck DB
- [ ] Post-DL-1 smoke: rotate the key, verify `org_id` preserved in precheck DB