### PR TITLE
Wire Stripe self-serve billing

### DIFF
--- a/apps/platform/.env.example
+++ b/apps/platform/.env.example
@@ -1,0 +1,14 @@
+# Database
+DATABASE_URL="postgresql://username:password@localhost:5432/governs_ai"
+
+# Auth
+JWT_SECRET="replace-me"
+NEXT_PUBLIC_APP_URL="http://localhost:3002"
+NEXT_PUBLIC_PLATFORM_URL="http://localhost:3002"
+
+# Internal webhook signing
+WEBHOOK_SECRET="replace-me"
+
+# Stripe billing
+STRIPE_SECRET_KEY="sk_test_replace_me"
+STRIPE_WEBHOOK_SECRET="whsec_replace_me"

--- a/apps/platform/.env.example
+++ b/apps/platform/.env.example
@@ -10,5 +10,5 @@ NEXT_PUBLIC_PLATFORM_URL="http://localhost:3002"
 WEBHOOK_SECRET="replace-me"
 
 # Stripe billing
-STRIPE_SECRET_KEY="sk_test_replace_me"
-STRIPE_WEBHOOK_SECRET="whsec_replace_me"
+STRIPE_SECRET_KEY="sk_test_placeholder"
+STRIPE_WEBHOOK_SECRET="whsec_placeholder"

--- a/apps/platform/__mocks__/prisma.ts
+++ b/apps/platform/__mocks__/prisma.ts
@@ -3,6 +3,16 @@
  * with a jest.fn() so tests can configure return values without a real DB.
  */
 
+class PrismaClientKnownRequestError extends Error {
+  code: string;
+
+  constructor(message: string, { code }: { code: string }) {
+    super(message);
+    this.code = code;
+    this.name = 'PrismaClientKnownRequestError';
+  }
+}
+
 export const prisma = {
   org: {
     findFirst: jest.fn(),
@@ -55,4 +65,8 @@ export const prisma = {
   contextMemory: {
     findFirst: jest.fn(),
   },
+};
+
+export const Prisma = {
+  PrismaClientKnownRequestError,
 };

--- a/apps/platform/__mocks__/prisma.ts
+++ b/apps/platform/__mocks__/prisma.ts
@@ -4,6 +4,11 @@
  */
 
 export const prisma = {
+  org: {
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
   aPIKey: {
     findMany: jest.fn(),
     findFirst: jest.fn(),

--- a/apps/platform/__tests__/api/billing-checkout.test.ts
+++ b/apps/platform/__tests__/api/billing-checkout.test.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@governs-ai/db';
 
 jest.mock('@/lib/session', () => ({
-  requireAuth: jest.fn(),
+  requireRole: jest.fn(),
 }));
 
 const mockCreateSession = jest.fn();
@@ -22,10 +22,10 @@ jest.mock('stripe', () => {
   };
 });
 
-import { requireAuth } from '@/lib/session';
+import { requireRole } from '@/lib/session';
 import { POST } from '@/app/api/v1/billing/checkout/route';
 
-const mockAuth = requireAuth as jest.Mock;
+const mockRequireRole = requireRole as jest.Mock;
 const mockPrisma = prisma as any;
 const AUTH_CTX = { orgId: 'org-1', userId: 'user-1', roles: ['OWNER'], orgSlug: 'acme', session: {} };
 
@@ -44,23 +44,23 @@ beforeEach(() => {
 
 describe('POST /api/v1/billing/checkout', () => {
   it('returns 401 when unauthenticated', async () => {
-    mockAuth.mockRejectedValue(new Error('Authentication required'));
+    mockRequireRole.mockRejectedValue(new Error('Authentication required'));
 
-    const res = await POST(makeReq({ tier: 'starter' }));
+    const res = await POST(makeReq({ tier: 'starter', seats: 1 }));
 
     expect(res.status).toBe(401);
   });
 
   it('returns 400 for unsupported tiers', async () => {
-    mockAuth.mockResolvedValue(AUTH_CTX);
+    mockRequireRole.mockResolvedValue(AUTH_CTX);
 
-    const res = await POST(makeReq({ tier: 'enterprise' }));
+    const res = await POST(makeReq({ tier: 'enterprise', seats: 1 }));
 
     expect(res.status).toBe(400);
   });
 
-  it('creates a Stripe checkout session for Starter', async () => {
-    mockAuth.mockResolvedValue(AUTH_CTX);
+  it('creates a Stripe checkout session for Starter with the requested seat count', async () => {
+    mockRequireRole.mockResolvedValue(AUTH_CTX);
     mockPrisma.org.findUnique.mockResolvedValue({
       id: 'org-1',
       name: 'Acme',
@@ -78,27 +78,34 @@ describe('POST /api/v1/billing/checkout', () => {
       url: 'https://checkout.stripe.com/pay/cs_test_123',
     });
 
-    const res = await POST(makeReq({ tier: 'starter' }));
+    const res = await POST(makeReq({ tier: 'starter', seats: 3 }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.redirectUrl).toBe('https://checkout.stripe.com/pay/cs_test_123');
+    expect(body.url).toBe('https://checkout.stripe.com/pay/cs_test_123');
     expect(mockCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'subscription',
         client_reference_id: 'org-1',
         customer_email: 'owner@example.com',
+        success_url: 'http://localhost:3002/o/acme/pricing?checkout=success&tier=starter',
+        cancel_url: 'http://localhost:3002/o/acme/pricing?checkout=canceled&tier=starter',
         metadata: expect.objectContaining({
           orgId: 'org-1',
           tier: 'starter',
           initiatedBy: 'user-1',
         }),
+        line_items: [
+          expect.objectContaining({
+            quantity: 3,
+          }),
+        ],
       })
     );
   });
 
   it('returns 409 when the requested plan is already active', async () => {
-    mockAuth.mockResolvedValue(AUTH_CTX);
+    mockRequireRole.mockResolvedValue(AUTH_CTX);
     mockPrisma.org.findUnique.mockResolvedValue({
       id: 'org-1',
       name: 'Acme',
@@ -109,9 +116,30 @@ describe('POST /api/v1/billing/checkout', () => {
     });
     mockPrisma.user.findUnique.mockResolvedValue({ email: 'owner@example.com', name: 'Owner' });
 
-    const res = await POST(makeReq({ tier: 'growth' }));
+    const res = await POST(makeReq({ tier: 'growth', seats: 1 }));
 
     expect(res.status).toBe(409);
     expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when billing is not configured', async () => {
+    const originalSecret = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+
+    const res = await POST(makeReq({ tier: 'starter', seats: 1 }));
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'billing not configured' });
+
+    process.env.STRIPE_SECRET_KEY = originalSecret;
+  });
+
+  it('returns 403 when the user is not an owner', async () => {
+    mockRequireRole.mockRejectedValue(new Error('Role OWNER required'));
+
+    const res = await POST(makeReq({ tier: 'starter', seats: 1 }));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Owner role required' });
   });
 });

--- a/apps/platform/__tests__/api/billing-checkout.test.ts
+++ b/apps/platform/__tests__/api/billing-checkout.test.ts
@@ -1,0 +1,117 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@governs-ai/db';
+
+jest.mock('@/lib/session', () => ({
+  requireAuth: jest.fn(),
+}));
+
+const mockCreateSession = jest.fn();
+
+jest.mock('stripe', () => {
+  const Stripe = jest.fn().mockImplementation(() => ({
+    checkout: {
+      sessions: {
+        create: mockCreateSession,
+      },
+    },
+  }));
+
+  return {
+    __esModule: true,
+    default: Stripe,
+  };
+});
+
+import { requireAuth } from '@/lib/session';
+import { POST } from '@/app/api/v1/billing/checkout/route';
+
+const mockAuth = requireAuth as jest.Mock;
+const mockPrisma = prisma as any;
+const AUTH_CTX = { orgId: 'org-1', userId: 'user-1', roles: ['OWNER'], orgSlug: 'acme', session: {} };
+
+function makeReq(body?: unknown) {
+  return new NextRequest('http://localhost/api/v1/billing/checkout', {
+    method: 'POST',
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3002';
+});
+
+describe('POST /api/v1/billing/checkout', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockAuth.mockRejectedValue(new Error('Authentication required'));
+
+    const res = await POST(makeReq({ tier: 'starter' }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for unsupported tiers', async () => {
+    mockAuth.mockResolvedValue(AUTH_CTX);
+
+    const res = await POST(makeReq({ tier: 'enterprise' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a Stripe checkout session for Starter', async () => {
+    mockAuth.mockResolvedValue(AUTH_CTX);
+    mockPrisma.org.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Acme',
+      slug: 'acme',
+      billingTier: 'free',
+      billingStatus: 'inactive',
+      stripeCustomerId: null,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      email: 'owner@example.com',
+      name: 'Owner',
+    });
+    mockCreateSession.mockResolvedValue({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.com/pay/cs_test_123',
+    });
+
+    const res = await POST(makeReq({ tier: 'starter' }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.redirectUrl).toBe('https://checkout.stripe.com/pay/cs_test_123');
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'subscription',
+        client_reference_id: 'org-1',
+        customer_email: 'owner@example.com',
+        metadata: expect.objectContaining({
+          orgId: 'org-1',
+          tier: 'starter',
+          initiatedBy: 'user-1',
+        }),
+      })
+    );
+  });
+
+  it('returns 409 when the requested plan is already active', async () => {
+    mockAuth.mockResolvedValue(AUTH_CTX);
+    mockPrisma.org.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Acme',
+      slug: 'acme',
+      billingTier: 'growth',
+      billingStatus: 'active',
+      stripeCustomerId: 'cus_123',
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({ email: 'owner@example.com', name: 'Owner' });
+
+    const res = await POST(makeReq({ tier: 'growth' }));
+
+    expect(res.status).toBe(409);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/platform/__tests__/api/billing-webhook.test.ts
+++ b/apps/platform/__tests__/api/billing-webhook.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { prisma } from '@governs-ai/db';
+import { Prisma, prisma } from '@governs-ai/db';
 
 const mockConstructEvent = jest.fn();
 
@@ -56,6 +56,7 @@ describe('POST /api/v1/billing/webhook', () => {
 
   it('activates the organization when checkout completes', async () => {
     mockConstructEvent.mockReturnValue({
+      id: 'evt_checkout_completed',
       type: 'checkout.session.completed',
       data: {
         object: {
@@ -70,11 +71,18 @@ describe('POST /api/v1/billing/webhook', () => {
         },
       },
     });
+    mockPrisma.webhookIdempotencyKey.create.mockResolvedValue({});
     mockPrisma.org.update.mockResolvedValue({});
 
     const res = await POST(makeReq('{"type":"checkout.session.completed"}'));
 
     expect(res.status).toBe(200);
+    expect(mockPrisma.webhookIdempotencyKey.create).toHaveBeenCalledWith({
+      data: {
+        idempotencyKey: 'evt_checkout_completed',
+        eventType: 'checkout.session.completed',
+      },
+    });
     expect(mockPrisma.org.update).toHaveBeenCalledWith({
       where: { id: 'org-1' },
       data: {
@@ -88,6 +96,7 @@ describe('POST /api/v1/billing/webhook', () => {
 
   it('restricts the organization when a subscription is deleted', async () => {
     mockConstructEvent.mockReturnValue({
+      id: 'evt_subscription_deleted',
       type: 'customer.subscription.deleted',
       data: {
         object: {
@@ -97,6 +106,7 @@ describe('POST /api/v1/billing/webhook', () => {
         },
       },
     });
+    mockPrisma.webhookIdempotencyKey.create.mockResolvedValue({});
     mockPrisma.org.findFirst.mockResolvedValue({ id: 'org-1' });
     mockPrisma.org.update.mockResolvedValue({});
 
@@ -113,5 +123,48 @@ describe('POST /api/v1/billing/webhook', () => {
         stripeSubscriptionId: null,
       },
     });
+  });
+
+  it('returns 503 when billing is not configured', async () => {
+    const originalSecret = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+
+    const res = await POST(makeReq('{}'));
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'billing not configured' });
+
+    process.env.STRIPE_SECRET_KEY = originalSecret;
+  });
+
+  it('ignores duplicate Stripe events', async () => {
+    mockConstructEvent.mockReturnValue({
+      id: 'evt_duplicate',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_123',
+          client_reference_id: 'org-1',
+          customer: 'cus_123',
+          subscription: 'sub_123',
+          metadata: {
+            orgId: 'org-1',
+            tier: 'starter',
+          },
+        },
+      },
+    });
+    mockPrisma.webhookIdempotencyKey.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('duplicate', {
+        code: 'P2002',
+        clientVersion: 'test',
+      })
+    );
+
+    const res = await POST(makeReq('{"type":"checkout.session.completed"}'));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ received: true, duplicate: true });
+    expect(mockPrisma.org.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/platform/__tests__/api/billing-webhook.test.ts
+++ b/apps/platform/__tests__/api/billing-webhook.test.ts
@@ -1,0 +1,117 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@governs-ai/db';
+
+const mockConstructEvent = jest.fn();
+
+class StripeSignatureVerificationError extends Error {}
+
+jest.mock('stripe', () => {
+  const Stripe = jest.fn().mockImplementation(() => ({
+    webhooks: {
+      constructEvent: mockConstructEvent,
+    },
+  }));
+
+  (Stripe as any).errors = {
+    StripeSignatureVerificationError,
+  };
+
+  return {
+    __esModule: true,
+    default: Stripe,
+  };
+});
+
+import { POST } from '@/app/api/v1/billing/webhook/route';
+
+const mockPrisma = prisma as any;
+
+function makeReq(payload: string, signature = 't=1,v1=abc') {
+  return new NextRequest('http://localhost/api/v1/billing/webhook', {
+    method: 'POST',
+    body: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      'stripe-signature': signature,
+    },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/v1/billing/webhook', () => {
+  it('returns 400 when Stripe signature verification fails', async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new StripeSignatureVerificationError('invalid signature');
+    });
+
+    const res = await POST(makeReq('{}'));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid Stripe signature');
+  });
+
+  it('activates the organization when checkout completes', async () => {
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_123',
+          client_reference_id: 'org-1',
+          customer: 'cus_123',
+          subscription: 'sub_123',
+          metadata: {
+            orgId: 'org-1',
+            tier: 'starter',
+          },
+        },
+      },
+    });
+    mockPrisma.org.update.mockResolvedValue({});
+
+    const res = await POST(makeReq('{"type":"checkout.session.completed"}'));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.org.update).toHaveBeenCalledWith({
+      where: { id: 'org-1' },
+      data: {
+        billingTier: 'starter',
+        billingStatus: 'active',
+        stripeCustomerId: 'cus_123',
+        stripeSubscriptionId: 'sub_123',
+      },
+    });
+  });
+
+  it('restricts the organization when a subscription is deleted', async () => {
+    mockConstructEvent.mockReturnValue({
+      type: 'customer.subscription.deleted',
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_123',
+          metadata: {},
+        },
+      },
+    });
+    mockPrisma.org.findFirst.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.org.update.mockResolvedValue({});
+
+    const res = await POST(makeReq('{"type":"customer.subscription.deleted"}'));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.org.findFirst).toHaveBeenCalled();
+    expect(mockPrisma.org.update).toHaveBeenCalledWith({
+      where: { id: 'org-1' },
+      data: {
+        billingTier: 'restricted',
+        billingStatus: 'canceled',
+        stripeCustomerId: 'cus_123',
+        stripeSubscriptionId: null,
+      },
+    });
+  });
+});

--- a/apps/platform/__tests__/middleware.test.ts
+++ b/apps/platform/__tests__/middleware.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+import middleware from '@/middleware';
+
+describe('platform middleware', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects restricted org routes to org-scoped pricing', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ restricted: true }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+
+    const response = await middleware(
+      new NextRequest('http://localhost/o/acme/dashboard', {
+        headers: {
+          cookie: 'session=test-session',
+        },
+      })
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/o/acme/pricing?billing=restricted');
+  });
+
+  it('blocks restricted state-changing API routes with 402', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ restricted: true }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+
+    const response = await middleware(
+      new NextRequest('http://localhost/api/v1/policies', {
+        method: 'POST',
+        headers: {
+          cookie: 'session=test-session',
+        },
+      })
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Organization access is restricted until billing is restored',
+    });
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  it('allows billing checkout requests to proceed for recovery', async () => {
+    const response = await middleware(
+      new NextRequest('http://localhost/api/v1/billing/checkout', {
+        method: 'POST',
+        headers: {
+          cookie: 'session=test-session',
+        },
+      })
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+  });
+});

--- a/apps/platform/app/api/billing/checkout/route.ts
+++ b/apps/platform/app/api/billing/checkout/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/v1/billing/checkout/route';

--- a/apps/platform/app/api/billing/webhook/route.ts
+++ b/apps/platform/app/api/billing/webhook/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/v1/billing/webhook/route';

--- a/apps/platform/app/api/v1/billing/checkout/route.ts
+++ b/apps/platform/app/api/v1/billing/checkout/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { z } from 'zod';
+import { prisma } from '@governs-ai/db';
+import { getBillingPlan } from '@/lib/billing';
+import { getValidAppUrl } from '@/lib/constants';
+
+const checkoutSchema = z.object({
+  tier: z.enum(['starter', 'growth']),
+});
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('STRIPE_SECRET_KEY environment variable is required');
+  }
+
+  return new Stripe(secretKey);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { requireAuth } = await import('@/lib/session');
+    const { orgId, userId } = await requireAuth(request);
+    const body = checkoutSchema.parse(await request.json());
+    const plan = getBillingPlan(body.tier);
+
+    if (!plan) {
+      return NextResponse.json({ error: 'Unsupported billing tier' }, { status: 400 });
+    }
+
+    const [org, user] = await Promise.all([
+      prisma.org.findUnique({
+        where: { id: orgId },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          billingTier: true,
+          billingStatus: true,
+          stripeCustomerId: true,
+        },
+      }),
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: { email: true, name: true },
+      }),
+    ]);
+
+    if (!org) {
+      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+    }
+
+    if (org.billingTier === plan.tier && org.billingStatus === 'active') {
+      return NextResponse.json(
+        { error: `${plan.name} is already active for this organization` },
+        { status: 409 }
+      );
+    }
+
+    const stripe = getStripeClient();
+    const baseUrl = getValidAppUrl();
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      billing_address_collection: 'auto',
+      allow_promotion_codes: false,
+      client_reference_id: org.id,
+      customer: org.stripeCustomerId || undefined,
+      customer_email: org.stripeCustomerId ? undefined : user?.email || undefined,
+      success_url: `${baseUrl}/pricing?checkout=success&tier=${plan.tier}`,
+      cancel_url: `${baseUrl}/pricing?checkout=canceled&tier=${plan.tier}`,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: 'usd',
+            recurring: { interval: 'month' },
+            unit_amount: plan.amountCents,
+            product_data: {
+              name: `GovernsAI ${plan.name}`,
+              description: plan.description,
+            },
+          },
+        },
+      ],
+      metadata: {
+        orgId: org.id,
+        orgSlug: org.slug,
+        tier: plan.tier,
+        initiatedBy: userId,
+        initiatedByEmail: user?.email || '',
+      },
+      subscription_data: {
+        metadata: {
+          orgId: org.id,
+          orgSlug: org.slug,
+          tier: plan.tier,
+        },
+      },
+    });
+
+    if (!session.url) {
+      return NextResponse.json(
+        { error: 'Stripe checkout session did not return a redirect URL' },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({
+      redirectUrl: session.url,
+      sessionId: session.id,
+    });
+  } catch (error) {
+    console.error('Stripe checkout error:', error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid request payload', details: error.issues },
+        { status: 400 }
+      );
+    }
+
+    if (error instanceof Error && error.message === 'Authentication required') {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create checkout session' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/app/api/v1/billing/checkout/route.ts
+++ b/apps/platform/app/api/v1/billing/checkout/route.ts
@@ -7,21 +7,22 @@ import { getValidAppUrl } from '@/lib/constants';
 
 const checkoutSchema = z.object({
   tier: z.enum(['starter', 'growth']),
+  seats: z.number().int().positive(),
 });
 
-function getStripeClient() {
-  const secretKey = process.env.STRIPE_SECRET_KEY;
-  if (!secretKey) {
-    throw new Error('STRIPE_SECRET_KEY environment variable is required');
-  }
-
+function getStripeClient(secretKey: string) {
   return new Stripe(secretKey);
 }
 
 export async function POST(request: NextRequest) {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    return NextResponse.json({ error: 'billing not configured' }, { status: 503 });
+  }
+
   try {
-    const { requireAuth } = await import('@/lib/session');
-    const { orgId, userId } = await requireAuth(request);
+    const { requireRole } = await import('@/lib/session');
+    const { orgId, userId } = await requireRole(request, 'OWNER');
     const body = checkoutSchema.parse(await request.json());
     const plan = getBillingPlan(body.tier);
 
@@ -58,7 +59,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const stripe = getStripeClient();
+    const stripe = getStripeClient(secretKey);
     const baseUrl = getValidAppUrl();
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
@@ -67,11 +68,11 @@ export async function POST(request: NextRequest) {
       client_reference_id: org.id,
       customer: org.stripeCustomerId || undefined,
       customer_email: org.stripeCustomerId ? undefined : user?.email || undefined,
-      success_url: `${baseUrl}/pricing?checkout=success&tier=${plan.tier}`,
-      cancel_url: `${baseUrl}/pricing?checkout=canceled&tier=${plan.tier}`,
+      success_url: `${baseUrl}/o/${org.slug}/pricing?checkout=success&tier=${plan.tier}`,
+      cancel_url: `${baseUrl}/o/${org.slug}/pricing?checkout=canceled&tier=${plan.tier}`,
       line_items: [
         {
-          quantity: 1,
+          quantity: body.seats,
           price_data: {
             currency: 'usd',
             recurring: { interval: 'month' },
@@ -106,10 +107,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.json({
-      redirectUrl: session.url,
-      sessionId: session.id,
-    });
+    return NextResponse.json({ url: session.url });
   } catch (error) {
     console.error('Stripe checkout error:', error);
 
@@ -124,9 +122,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to create checkout session' },
-      { status: 500 }
-    );
+    if (error instanceof Error && error.message === 'Role OWNER required') {
+      return NextResponse.json({ error: 'Owner role required' }, { status: 403 });
+    }
+
+    return NextResponse.json({ error: 'Failed to create checkout session' }, { status: 500 });
   }
 }

--- a/apps/platform/app/api/v1/billing/webhook/route.ts
+++ b/apps/platform/app/api/v1/billing/webhook/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { prisma } from '@governs-ai/db';
+import { isSelfServeBillingTier } from '@/lib/billing';
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('STRIPE_SECRET_KEY environment variable is required');
+  }
+
+  return new Stripe(secretKey);
+}
+
+function getWebhookSecret() {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+  }
+
+  return secret;
+}
+
+function getStripeId(value: string | Stripe.Customer | Stripe.Subscription | Stripe.DeletedCustomer | null) {
+  if (!value) {
+    return null;
+  }
+
+  return typeof value === 'string' ? value : value.id;
+}
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
+  const orgId = session.metadata?.orgId || session.client_reference_id;
+  const tier = session.metadata?.tier;
+
+  if (!orgId || !tier || !isSelfServeBillingTier(tier)) {
+    console.warn('Stripe checkout completed without usable org metadata', {
+      sessionId: session.id,
+      orgId,
+      tier,
+    });
+    return;
+  }
+
+  await prisma.org.update({
+    where: { id: orgId },
+    data: {
+      billingTier: tier,
+      billingStatus: 'active',
+      stripeCustomerId: getStripeId(session.customer),
+      stripeSubscriptionId: getStripeId(session.subscription),
+    },
+  });
+}
+
+async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
+  const metadataOrgId = subscription.metadata?.orgId;
+  const customerId = getStripeId(subscription.customer);
+
+  const org =
+    (metadataOrgId
+      ? await prisma.org.findUnique({
+          where: { id: metadataOrgId },
+          select: { id: true },
+        })
+      : null) ||
+    (await prisma.org.findFirst({
+      where: {
+        OR: [
+          { stripeSubscriptionId: subscription.id },
+          ...(customerId ? [{ stripeCustomerId: customerId }] : []),
+        ],
+      },
+      select: { id: true },
+    }));
+
+  if (!org) {
+    console.warn('Stripe subscription deletion could not resolve an org', {
+      subscriptionId: subscription.id,
+      metadataOrgId,
+      customerId,
+    });
+    return;
+  }
+
+  await prisma.org.update({
+    where: { id: org.id },
+    data: {
+      billingTier: 'restricted',
+      billingStatus: 'canceled',
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: null,
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text();
+    const signature = request.headers.get('stripe-signature');
+
+    if (!signature) {
+      return NextResponse.json({ error: 'Missing stripe-signature header' }, { status: 400 });
+    }
+
+    const stripe = getStripeClient();
+    const event = stripe.webhooks.constructEvent(rawBody, signature, getWebhookSecret());
+
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        break;
+      case 'customer.subscription.deleted':
+        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+        break;
+      default:
+        console.log('Stripe webhook received unhandled event', event.type);
+        break;
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error('Stripe webhook error:', error);
+
+    if (error instanceof Stripe.errors.StripeSignatureVerificationError) {
+      return NextResponse.json({ error: 'Invalid Stripe signature' }, { status: 400 });
+    }
+
+    if (error instanceof Error && error.message.toLowerCase().includes('signature')) {
+      return NextResponse.json({ error: 'Invalid Stripe signature' }, { status: 400 });
+    }
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to process Stripe webhook' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/app/api/v1/billing/webhook/route.ts
+++ b/apps/platform/app/api/v1/billing/webhook/route.ts
@@ -1,24 +1,38 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { prisma } from '@governs-ai/db';
+import { Prisma, prisma } from '@governs-ai/db';
 import { isSelfServeBillingTier } from '@/lib/billing';
 
-function getStripeClient() {
-  const secretKey = process.env.STRIPE_SECRET_KEY;
-  if (!secretKey) {
-    throw new Error('STRIPE_SECRET_KEY environment variable is required');
-  }
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
+function getStripeClient(secretKey: string) {
   return new Stripe(secretKey);
 }
 
-function getWebhookSecret() {
-  const secret = process.env.STRIPE_WEBHOOK_SECRET;
-  if (!secret) {
-    throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
-  }
+async function recordWebhookEvent(event: Stripe.Event) {
+  try {
+    await prisma.webhookIdempotencyKey.create({
+      data: {
+        idempotencyKey: event.id,
+        eventType: event.type,
+      },
+    });
+    return false;
+  } catch (error) {
+    const isDuplicateKeyError =
+      (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') ||
+      (typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code?: string }).code === 'P2002');
 
-  return secret;
+    if (isDuplicateKeyError) {
+      return true;
+    }
+
+    throw error;
+  }
 }
 
 function getStripeId(value: string | Stripe.Customer | Stripe.Subscription | Stripe.DeletedCustomer | null) {
@@ -95,6 +109,13 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
 }
 
 export async function POST(request: NextRequest) {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!secretKey || !webhookSecret) {
+    return NextResponse.json({ error: 'billing not configured' }, { status: 503 });
+  }
+
   try {
     const rawBody = await request.text();
     const signature = request.headers.get('stripe-signature');
@@ -103,8 +124,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing stripe-signature header' }, { status: 400 });
     }
 
-    const stripe = getStripeClient();
-    const event = stripe.webhooks.constructEvent(rawBody, signature, getWebhookSecret());
+    const stripe = getStripeClient(secretKey);
+    const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+
+    const duplicate = await recordWebhookEvent(event);
+    if (duplicate) {
+      return NextResponse.json({ received: true, duplicate: true });
+    }
 
     switch (event.type) {
       case 'checkout.session.completed':
@@ -114,7 +140,7 @@ export async function POST(request: NextRequest) {
         await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
         break;
       default:
-        console.log('Stripe webhook received unhandled event', event.type);
+        console.warn('Stripe webhook received unhandled event', event.type);
         break;
     }
 
@@ -130,9 +156,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid Stripe signature' }, { status: 400 });
     }
 
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to process Stripe webhook' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to process Stripe webhook' }, { status: 500 });
   }
 }

--- a/apps/platform/app/api/v1/internal/org-access/route.ts
+++ b/apps/platform/app/api/v1/internal/org-access/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getOrgRequestContext, getRequestContext, isOrgBillingRestricted } from '@/lib/session';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const orgSlug = request.nextUrl.searchParams.get('slug') || undefined;
+  const baseContext = await getRequestContext(request);
+
+  if (!baseContext) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const context = await getOrgRequestContext(request, { orgSlug });
+
+  if (!context) {
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    authenticated: true,
+    orgId: context.orgId,
+    orgSlug: context.orgSlug,
+    billingTier: context.billingTier,
+    billingStatus: context.billingStatus,
+    restricted: isOrgBillingRestricted(context),
+  });
+}

--- a/apps/platform/app/api/v1/profile/route.ts
+++ b/apps/platform/app/api/v1/profile/route.ts
@@ -81,12 +81,16 @@ export async function GET(request: NextRequest) {
                 name: m.org.name,
                 slug: m.org.slug,
                 role: m.role,
+                billingTier: m.org.billingTier,
+                billingStatus: m.org.billingStatus,
             })),
             activeOrg: activeOrg ? {
                 id: activeOrg.org.id,
                 name: activeOrg.org.name,
                 slug: activeOrg.org.slug,
                 role: activeOrg.role,
+                billingTier: activeOrg.org.billingTier,
+                billingStatus: activeOrg.org.billingStatus,
             } : null,
         });
     } catch (error) {
@@ -144,4 +148,4 @@ export async function PUT(request: NextRequest) {
             { status: 500 }
         );
     }
-} 
+}

--- a/apps/platform/app/o/[slug]/pricing/page.tsx
+++ b/apps/platform/app/o/[slug]/pricing/page.tsx
@@ -1,0 +1,11 @@
+import { PricingPageClient } from './pricing-page-client';
+
+export default async function OrganizationPricingPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return <PricingPageClient slug={slug} />;
+}

--- a/apps/platform/app/o/[slug]/pricing/pricing-page-client.tsx
+++ b/apps/platform/app/o/[slug]/pricing/pricing-page-client.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { ArrowRight, Building2, Check, ShieldCheck, Zap } from 'lucide-react';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@governs-ai/ui';
+import { ENTERPRISE_PLAN, SELF_SERVE_BILLING_PLANS, type SelfServeBillingTier } from '@/lib/billing';
+import { useUser } from '@/lib/user-context';
+
+type Notice = {
+  tone: 'success' | 'warning' | 'error';
+  text: string;
+};
+
+const toneClasses: Record<Notice['tone'], string> = {
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+  error: 'border-rose-200 bg-rose-50 text-rose-900',
+};
+
+export function PricingPageClient({ slug }: { slug: string }) {
+  const searchParams = useSearchParams();
+  const { activeOrg, organizations, loading, refetch, switchActiveOrg } = useUser();
+  const [submittingTier, setSubmittingTier] = useState<SelfServeBillingTier | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  useEffect(() => {
+    const checkoutState = searchParams.get('checkout');
+    const billingState = searchParams.get('billing');
+
+    if (checkoutState === 'success') {
+      setNotice({
+        tone: 'success',
+        text: 'Checkout completed. Stripe is finishing the subscription handshake now.',
+      });
+      void refetch();
+      return;
+    }
+
+    if (checkoutState === 'canceled') {
+      setNotice({
+        tone: 'warning',
+        text: 'Checkout was canceled. Your organization plan was not changed.',
+      });
+      return;
+    }
+
+    if (billingState === 'restricted') {
+      setNotice({
+        tone: 'warning',
+        text: 'This organization is restricted until billing is restored. Use this page to reactivate service.',
+      });
+    }
+  }, [refetch, searchParams]);
+
+  const orgFromList = organizations.find((organization) => organization.slug === slug) || null;
+  const currentOrg = activeOrg?.slug === slug ? activeOrg : orgFromList;
+  const currentTier = currentOrg?.billingTier || 'free';
+  const currentStatus = currentOrg?.billingStatus || 'inactive';
+  const selfServePlans = Object.values(SELF_SERVE_BILLING_PLANS);
+
+  async function startCheckout(tier: SelfServeBillingTier) {
+    setNotice(null);
+
+    try {
+      setSubmittingTier(tier);
+
+      if (!activeOrg || activeOrg.slug !== slug) {
+        const switched = await switchActiveOrg(slug);
+        if (!switched) {
+          throw new Error('Failed to switch to the selected organization');
+        }
+      }
+
+      const response = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier, seats: 1 }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (response.status === 401) {
+        window.location.assign('/auth/login');
+        return;
+      }
+
+      if (!response.ok || !data.url) {
+        throw new Error(data.error || 'Failed to start checkout');
+      }
+
+      window.location.assign(data.url);
+    } catch (error) {
+      setNotice({
+        tone: 'error',
+        text: error instanceof Error ? error.message : 'Failed to start checkout',
+      });
+    } finally {
+      setSubmittingTier(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(36,209,181,0.18),_transparent_36%),linear-gradient(180deg,_#f7fbfb_0%,_#eef4f7_100%)]">
+      <section className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-16 lg:px-10">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-end">
+          <div className="space-y-6">
+            <Badge variant="secondary" className="w-fit border border-brand/20 bg-brand/10 text-foreground">
+              Self-serve billing
+            </Badge>
+            <div className="space-y-4">
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-primary sm:text-5xl">
+                Pick the governance tier that matches your rollout pace.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
+                Starter and Growth launch immediately through Stripe Checkout. Enterprise stays
+                sales-led for security review, rollout planning, and procurement.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
+                <ShieldCheck className="h-4 w-4 text-brand" />
+                Governance controls included
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
+                <Zap className="h-4 w-4 text-brand" />
+                Monthly subscriptions, billed in Stripe
+              </span>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-enterprise-md backdrop-blur">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Building2 className="h-4 w-4 text-brand" />
+              {loading
+                ? 'Loading organization context...'
+                : currentOrg
+                  ? `Viewing org: ${currentOrg.name}`
+                  : `Organization not found for slug "${slug}".`}
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-border bg-background/80 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Current tier</p>
+                <p className="mt-2 text-2xl font-semibold text-primary">{currentTier}</p>
+              </div>
+              <div className="rounded-2xl border border-border bg-background/80 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Subscription status</p>
+                <p className="mt-2 text-2xl font-semibold text-primary">{currentStatus}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {notice ? (
+          <div className={`rounded-2xl border px-4 py-3 text-sm shadow-enterprise-sm ${toneClasses[notice.tone]}`}>
+            {notice.text}
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          {selfServePlans.map((plan) => {
+            const isCurrentPlan = currentTier === plan.tier && currentStatus === 'active';
+            const isBusy = submittingTier === plan.tier;
+
+            return (
+              <Card
+                key={plan.tier}
+                className={`relative overflow-hidden border-white/70 bg-white/85 shadow-enterprise-md backdrop-blur ${
+                  plan.tier === 'growth' ? 'ring-2 ring-brand/70' : ''
+                }`}
+              >
+                <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-brand/0 via-brand to-primary/60" />
+                <CardHeader className="space-y-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <CardTitle className="text-3xl text-primary">{plan.name}</CardTitle>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{plan.description}</p>
+                    </div>
+                    {plan.tier === 'growth' ? <Badge>Most coverage</Badge> : null}
+                  </div>
+                  <div>
+                    <div className="text-4xl font-semibold tracking-tight text-primary">{plan.priceMonthly}</div>
+                    <p className="mt-2 text-sm text-muted-foreground">Billed monthly through Stripe Checkout.</p>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <ul className="space-y-3 text-sm text-foreground">
+                    {plan.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start gap-3">
+                        <span className="mt-0.5 rounded-full bg-brand/15 p-1 text-brand">
+                          <Check className="h-3.5 w-3.5" />
+                        </span>
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <Button
+                    className="w-full"
+                    variant={plan.tier === 'growth' ? 'brand' : 'default'}
+                    disabled={isBusy || isCurrentPlan || !currentOrg}
+                    onClick={() => startCheckout(plan.tier)}
+                  >
+                    {isCurrentPlan ? 'Current plan' : isBusy ? 'Redirecting...' : 'Start now'}
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          <Card className="relative overflow-hidden border-primary/15 bg-primary text-primary-foreground shadow-enterprise-lg">
+            <div className="absolute right-0 top-0 h-36 w-36 -translate-y-8 translate-x-8 rounded-full bg-brand/20 blur-3xl" />
+            <CardHeader className="space-y-5">
+              <Badge className="w-fit bg-white/10 text-primary-foreground hover:bg-white/10">
+                Enterprise
+              </Badge>
+              <div>
+                <CardTitle className="text-3xl">{ENTERPRISE_PLAN.name}</CardTitle>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/75">
+                  {ENTERPRISE_PLAN.description}
+                </p>
+              </div>
+              <div className="text-4xl font-semibold tracking-tight">{ENTERPRISE_PLAN.priceMonthly}</div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <ul className="space-y-3 text-sm text-primary-foreground">
+                {ENTERPRISE_PLAN.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-3">
+                    <span className="mt-0.5 rounded-full bg-white/10 p-1 text-brand">
+                      <Check className="h-3.5 w-3.5" />
+                    </span>
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Button asChild variant="secondary" className="w-full bg-white text-primary hover:bg-white/90">
+                <Link href="mailto:sales@governsai.com?subject=Enterprise%20Plan%20Inquiry">
+                  Talk to sales
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/platform/app/pricing/page.tsx
+++ b/apps/platform/app/pricing/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { ArrowRight, Building2, Check, ShieldCheck, Zap } from 'lucide-react';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@governs-ai/ui';
+import { ENTERPRISE_PLAN, SELF_SERVE_BILLING_PLANS, type SelfServeBillingTier } from '@/lib/billing';
+import { useUser } from '@/lib/user-context';
+
+type Notice = {
+  tone: 'success' | 'warning' | 'error';
+  text: string;
+};
+
+const toneClasses: Record<Notice['tone'], string> = {
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+  error: 'border-rose-200 bg-rose-50 text-rose-900',
+};
+
+export default function PricingPage() {
+  const searchParams = useSearchParams();
+  const { activeOrg, loading, refetch } = useUser();
+  const [submittingTier, setSubmittingTier] = useState<SelfServeBillingTier | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  useEffect(() => {
+    const checkoutState = searchParams.get('checkout');
+    if (checkoutState === 'success') {
+      setNotice({
+        tone: 'success',
+        text: 'Checkout completed. Stripe is finishing the subscription handshake now.',
+      });
+      void refetch();
+      return;
+    }
+
+    if (checkoutState === 'canceled') {
+      setNotice({
+        tone: 'warning',
+        text: 'Checkout was canceled. Your organization plan was not changed.',
+      });
+    }
+  }, [refetch, searchParams]);
+
+  const currentTier = activeOrg?.billingTier || 'free';
+  const currentStatus = activeOrg?.billingStatus || 'inactive';
+
+  const selfServePlans = useMemo(() => Object.values(SELF_SERVE_BILLING_PLANS), []);
+
+  async function startCheckout(tier: SelfServeBillingTier) {
+    setNotice(null);
+
+    if (!activeOrg) {
+      window.location.assign('/auth/login');
+      return;
+    }
+
+    try {
+      setSubmittingTier(tier);
+      const response = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (response.status === 401) {
+        window.location.assign('/auth/login');
+        return;
+      }
+
+      if (!response.ok || !data.redirectUrl) {
+        throw new Error(data.error || 'Failed to start checkout');
+      }
+
+      window.location.assign(data.redirectUrl);
+    } catch (error) {
+      setNotice({
+        tone: 'error',
+        text: error instanceof Error ? error.message : 'Failed to start checkout',
+      });
+    } finally {
+      setSubmittingTier(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(36,209,181,0.18),_transparent_36%),linear-gradient(180deg,_#f7fbfb_0%,_#eef4f7_100%)]">
+      <section className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-16 lg:px-10">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-end">
+          <div className="space-y-6">
+            <Badge variant="secondary" className="w-fit border border-brand/20 bg-brand/10 text-foreground">
+              Self-serve billing
+            </Badge>
+            <div className="space-y-4">
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-primary sm:text-5xl">
+                Pick the governance tier that matches your rollout pace.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
+                Starter and Growth launch immediately through Stripe Checkout. Enterprise stays
+                sales-led for security review, rollout planning, and procurement.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
+                <ShieldCheck className="h-4 w-4 text-brand" />
+                Governance controls included
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
+                <Zap className="h-4 w-4 text-brand" />
+                Monthly subscriptions, billed in Stripe
+              </span>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-enterprise-md backdrop-blur">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Building2 className="h-4 w-4 text-brand" />
+              {loading
+                ? 'Loading organization context...'
+                : activeOrg
+                  ? `Active org: ${activeOrg.name}`
+                  : 'Sign in to start a subscription for your organization.'}
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-border bg-background/80 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Current tier</p>
+                <p className="mt-2 text-2xl font-semibold text-primary">{currentTier}</p>
+              </div>
+              <div className="rounded-2xl border border-border bg-background/80 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Subscription status</p>
+                <p className="mt-2 text-2xl font-semibold text-primary">{currentStatus}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {notice ? (
+          <div className={`rounded-2xl border px-4 py-3 text-sm shadow-enterprise-sm ${toneClasses[notice.tone]}`}>
+            {notice.text}
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          {selfServePlans.map((plan) => {
+            const isCurrentPlan = currentTier === plan.tier && currentStatus === 'active';
+            const isBusy = submittingTier === plan.tier;
+
+            return (
+              <Card
+                key={plan.tier}
+                className={`relative overflow-hidden border-white/70 bg-white/85 shadow-enterprise-md backdrop-blur ${
+                  plan.tier === 'growth' ? 'ring-2 ring-brand/70' : ''
+                }`}
+              >
+                <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-brand/0 via-brand to-primary/60" />
+                <CardHeader className="space-y-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <CardTitle className="text-3xl text-primary">{plan.name}</CardTitle>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{plan.description}</p>
+                    </div>
+                    {plan.tier === 'growth' ? <Badge>Most coverage</Badge> : null}
+                  </div>
+                  <div>
+                    <div className="text-4xl font-semibold tracking-tight text-primary">{plan.priceMonthly}</div>
+                    <p className="mt-2 text-sm text-muted-foreground">Billed monthly through Stripe Checkout.</p>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <ul className="space-y-3 text-sm text-foreground">
+                    {plan.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start gap-3">
+                        <span className="mt-0.5 rounded-full bg-brand/15 p-1 text-brand">
+                          <Check className="h-3.5 w-3.5" />
+                        </span>
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <Button
+                    className="w-full"
+                    variant={plan.tier === 'growth' ? 'brand' : 'default'}
+                    disabled={isBusy || isCurrentPlan}
+                    onClick={() => startCheckout(plan.tier)}
+                  >
+                    {isCurrentPlan ? 'Current plan' : isBusy ? 'Redirecting...' : 'Start now'}
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          <Card className="relative overflow-hidden border-primary/15 bg-primary text-primary-foreground shadow-enterprise-lg">
+            <div className="absolute right-0 top-0 h-36 w-36 -translate-y-8 translate-x-8 rounded-full bg-brand/20 blur-3xl" />
+            <CardHeader className="space-y-5">
+              <Badge className="w-fit bg-white/10 text-primary-foreground hover:bg-white/10">
+                Enterprise
+              </Badge>
+              <div>
+                <CardTitle className="text-3xl">{ENTERPRISE_PLAN.name}</CardTitle>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/75">
+                  {ENTERPRISE_PLAN.description}
+                </p>
+              </div>
+              <div className="text-4xl font-semibold tracking-tight">{ENTERPRISE_PLAN.priceMonthly}</div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <ul className="space-y-3 text-sm text-primary-foreground">
+                {ENTERPRISE_PLAN.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-3">
+                    <span className="mt-0.5 rounded-full bg-white/10 p-1 text-brand">
+                      <Check className="h-3.5 w-3.5" />
+                    </span>
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Button asChild variant="secondary" className="w-full bg-white text-primary hover:bg-white/90">
+                <Link href="mailto:sales@governsai.com?subject=Enterprise%20Plan%20Inquiry">
+                  Talk to sales
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/platform/app/pricing/page.tsx
+++ b/apps/platform/app/pricing/page.tsx
@@ -1,239 +1,34 @@
 'use client';
 
-import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { ArrowRight, Building2, Check, ShieldCheck, Zap } from 'lucide-react';
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@governs-ai/ui';
-import { ENTERPRISE_PLAN, SELF_SERVE_BILLING_PLANS, type SelfServeBillingTier } from '@/lib/billing';
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useUser } from '@/lib/user-context';
 
-type Notice = {
-  tone: 'success' | 'warning' | 'error';
-  text: string;
-};
-
-const toneClasses: Record<Notice['tone'], string> = {
-  success: 'border-emerald-200 bg-emerald-50 text-emerald-900',
-  warning: 'border-amber-200 bg-amber-50 text-amber-900',
-  error: 'border-rose-200 bg-rose-50 text-rose-900',
-};
-
-export default function PricingPage() {
+export default function LegacyPricingPage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const { activeOrg, loading, refetch } = useUser();
-  const [submittingTier, setSubmittingTier] = useState<SelfServeBillingTier | null>(null);
-  const [notice, setNotice] = useState<Notice | null>(null);
+  const { activeOrg, loading } = useUser();
 
   useEffect(() => {
-    const checkoutState = searchParams.get('checkout');
-    if (checkoutState === 'success') {
-      setNotice({
-        tone: 'success',
-        text: 'Checkout completed. Stripe is finishing the subscription handshake now.',
-      });
-      void refetch();
+    if (loading) {
       return;
     }
-
-    if (checkoutState === 'canceled') {
-      setNotice({
-        tone: 'warning',
-        text: 'Checkout was canceled. Your organization plan was not changed.',
-      });
-    }
-  }, [refetch, searchParams]);
-
-  const currentTier = activeOrg?.billingTier || 'free';
-  const currentStatus = activeOrg?.billingStatus || 'inactive';
-
-  const selfServePlans = useMemo(() => Object.values(SELF_SERVE_BILLING_PLANS), []);
-
-  async function startCheckout(tier: SelfServeBillingTier) {
-    setNotice(null);
 
     if (!activeOrg) {
-      window.location.assign('/auth/login');
+      router.replace('/auth/login');
       return;
     }
 
-    try {
-      setSubmittingTier(tier);
-      const response = await fetch('/api/billing/checkout', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ tier }),
-      });
-
-      const data = await response.json().catch(() => ({}));
-
-      if (response.status === 401) {
-        window.location.assign('/auth/login');
-        return;
-      }
-
-      if (!response.ok || !data.redirectUrl) {
-        throw new Error(data.error || 'Failed to start checkout');
-      }
-
-      window.location.assign(data.redirectUrl);
-    } catch (error) {
-      setNotice({
-        tone: 'error',
-        text: error instanceof Error ? error.message : 'Failed to start checkout',
-      });
-    } finally {
-      setSubmittingTier(null);
-    }
-  }
+    const nextQuery = searchParams.toString();
+    router.replace(`/o/${activeOrg.slug}/pricing${nextQuery ? `?${nextQuery}` : ''}`);
+  }, [activeOrg, loading, router, searchParams]);
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(36,209,181,0.18),_transparent_36%),linear-gradient(180deg,_#f7fbfb_0%,_#eef4f7_100%)]">
-      <section className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-16 lg:px-10">
-        <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-end">
-          <div className="space-y-6">
-            <Badge variant="secondary" className="w-fit border border-brand/20 bg-brand/10 text-foreground">
-              Self-serve billing
-            </Badge>
-            <div className="space-y-4">
-              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-primary sm:text-5xl">
-                Pick the governance tier that matches your rollout pace.
-              </h1>
-              <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
-                Starter and Growth launch immediately through Stripe Checkout. Enterprise stays
-                sales-led for security review, rollout planning, and procurement.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
-              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
-                <ShieldCheck className="h-4 w-4 text-brand" />
-                Governance controls included
-              </span>
-              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5">
-                <Zap className="h-4 w-4 text-brand" />
-                Monthly subscriptions, billed in Stripe
-              </span>
-            </div>
-          </div>
-
-          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-enterprise-md backdrop-blur">
-            <div className="flex items-center gap-3 text-sm text-muted-foreground">
-              <Building2 className="h-4 w-4 text-brand" />
-              {loading
-                ? 'Loading organization context...'
-                : activeOrg
-                  ? `Active org: ${activeOrg.name}`
-                  : 'Sign in to start a subscription for your organization.'}
-            </div>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-2xl border border-border bg-background/80 p-4">
-                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Current tier</p>
-                <p className="mt-2 text-2xl font-semibold text-primary">{currentTier}</p>
-              </div>
-              <div className="rounded-2xl border border-border bg-background/80 p-4">
-                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Subscription status</p>
-                <p className="mt-2 text-2xl font-semibold text-primary">{currentStatus}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {notice ? (
-          <div className={`rounded-2xl border px-4 py-3 text-sm shadow-enterprise-sm ${toneClasses[notice.tone]}`}>
-            {notice.text}
-          </div>
-        ) : null}
-
-        <div className="grid gap-6 lg:grid-cols-3">
-          {selfServePlans.map((plan) => {
-            const isCurrentPlan = currentTier === plan.tier && currentStatus === 'active';
-            const isBusy = submittingTier === plan.tier;
-
-            return (
-              <Card
-                key={plan.tier}
-                className={`relative overflow-hidden border-white/70 bg-white/85 shadow-enterprise-md backdrop-blur ${
-                  plan.tier === 'growth' ? 'ring-2 ring-brand/70' : ''
-                }`}
-              >
-                <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-brand/0 via-brand to-primary/60" />
-                <CardHeader className="space-y-5">
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <CardTitle className="text-3xl text-primary">{plan.name}</CardTitle>
-                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{plan.description}</p>
-                    </div>
-                    {plan.tier === 'growth' ? <Badge>Most coverage</Badge> : null}
-                  </div>
-                  <div>
-                    <div className="text-4xl font-semibold tracking-tight text-primary">{plan.priceMonthly}</div>
-                    <p className="mt-2 text-sm text-muted-foreground">Billed monthly through Stripe Checkout.</p>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  <ul className="space-y-3 text-sm text-foreground">
-                    {plan.highlights.map((highlight) => (
-                      <li key={highlight} className="flex items-start gap-3">
-                        <span className="mt-0.5 rounded-full bg-brand/15 p-1 text-brand">
-                          <Check className="h-3.5 w-3.5" />
-                        </span>
-                        <span>{highlight}</span>
-                      </li>
-                    ))}
-                  </ul>
-
-                  <Button
-                    className="w-full"
-                    variant={plan.tier === 'growth' ? 'brand' : 'default'}
-                    disabled={isBusy || isCurrentPlan}
-                    onClick={() => startCheckout(plan.tier)}
-                  >
-                    {isCurrentPlan ? 'Current plan' : isBusy ? 'Redirecting...' : 'Start now'}
-                  </Button>
-                </CardContent>
-              </Card>
-            );
-          })}
-
-          <Card className="relative overflow-hidden border-primary/15 bg-primary text-primary-foreground shadow-enterprise-lg">
-            <div className="absolute right-0 top-0 h-36 w-36 -translate-y-8 translate-x-8 rounded-full bg-brand/20 blur-3xl" />
-            <CardHeader className="space-y-5">
-              <Badge className="w-fit bg-white/10 text-primary-foreground hover:bg-white/10">
-                Enterprise
-              </Badge>
-              <div>
-                <CardTitle className="text-3xl">{ENTERPRISE_PLAN.name}</CardTitle>
-                <p className="mt-2 text-sm leading-6 text-primary-foreground/75">
-                  {ENTERPRISE_PLAN.description}
-                </p>
-              </div>
-              <div className="text-4xl font-semibold tracking-tight">{ENTERPRISE_PLAN.priceMonthly}</div>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <ul className="space-y-3 text-sm text-primary-foreground">
-                {ENTERPRISE_PLAN.highlights.map((highlight) => (
-                  <li key={highlight} className="flex items-start gap-3">
-                    <span className="mt-0.5 rounded-full bg-white/10 p-1 text-brand">
-                      <Check className="h-3.5 w-3.5" />
-                    </span>
-                    <span>{highlight}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <Button asChild variant="secondary" className="w-full bg-white text-primary hover:bg-white/90">
-                <Link href="mailto:sales@governsai.com?subject=Enterprise%20Plan%20Inquiry">
-                  Talk to sales
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-    </main>
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="text-center">
+        <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+        <p className="mt-2 text-sm text-muted-foreground">Redirecting to organization billing…</p>
+      </div>
+    </div>
   );
 }

--- a/apps/platform/jest.setup.ts
+++ b/apps/platform/jest.setup.ts
@@ -3,4 +3,6 @@
 process.env.WEBHOOK_SECRET = 'test-webhook-secret-for-ci';
 process.env.JWT_SECRET = 'test-jwt-secret-for-ci';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test_ci';
+process.env.STRIPE_SECRET_KEY = 'sk_test_billing_ci';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec_billing_ci';
 // NODE_ENV is read-only in TypeScript strict mode; it is already 'test' when jest runs

--- a/apps/platform/lib/billing.ts
+++ b/apps/platform/lib/billing.ts
@@ -1,0 +1,59 @@
+export type SelfServeBillingTier = 'starter' | 'growth';
+export type OrgBillingTier = 'free' | 'starter' | 'growth' | 'enterprise' | 'restricted';
+export type BillingStatus = 'inactive' | 'active' | 'canceled';
+
+export interface BillingPlan {
+  tier: SelfServeBillingTier;
+  name: string;
+  priceMonthly: string;
+  amountCents: number;
+  description: string;
+  highlights: string[];
+}
+
+export const SELF_SERVE_BILLING_PLANS: Record<SelfServeBillingTier, BillingPlan> = {
+  starter: {
+    tier: 'starter',
+    name: 'Starter',
+    priceMonthly: '$499/mo',
+    amountCents: 49900,
+    description: 'Operational governance for teams standardizing AI usage across one org.',
+    highlights: [
+      'Policy controls and audit trail',
+      'Usage visibility and budget alerts',
+      'Fast setup for a single production workspace',
+    ],
+  },
+  growth: {
+    tier: 'growth',
+    name: 'Growth',
+    priceMonthly: '$2,500/mo',
+    amountCents: 250000,
+    description: 'Expanded governance coverage for production rollouts and multi-team operations.',
+    highlights: [
+      'Higher-volume governance workflows',
+      'Advanced rollout support across teams',
+      'Best fit for central platform ownership',
+    ],
+  },
+};
+
+export const ENTERPRISE_PLAN = {
+  tier: 'enterprise' as const,
+  name: 'Enterprise',
+  priceMonthly: 'Custom',
+  description: 'Custom contracting for SSO, procurement, and dedicated rollout support.',
+  highlights: [
+    'Security and procurement alignment',
+    'Enterprise onboarding and architecture review',
+    'Custom plan design for larger deployments',
+  ],
+};
+
+export function isSelfServeBillingTier(value: string): value is SelfServeBillingTier {
+  return value === 'starter' || value === 'growth';
+}
+
+export function getBillingPlan(tier: string): BillingPlan | null {
+  return isSelfServeBillingTier(tier) ? SELF_SERVE_BILLING_PLANS[tier] : null;
+}

--- a/apps/platform/lib/session.ts
+++ b/apps/platform/lib/session.ts
@@ -10,26 +10,62 @@ export interface RequestContext {
   session: SessionData;
 }
 
-export async function getRequestContext(request: NextRequest): Promise<RequestContext | null> {
-  // Get session from cookie
+export interface OrgRequestContext extends RequestContext {
+  billingTier: string;
+  billingStatus: string;
+}
+
+export class BillingRestrictionError extends Error {
+  status = 402;
+
+  constructor(message = 'Organization access is restricted until billing is restored') {
+    super(message);
+    this.name = 'BillingRestrictionError';
+  }
+}
+
+function getSessionData(request: NextRequest): SessionData | null {
   const sessionToken = request.cookies.get('session')?.value;
   if (!sessionToken) return null;
 
-  const session = verifySessionToken(sessionToken);
+  return verifySessionToken(sessionToken);
+}
+
+async function resolveMembership(session: SessionData, options: { orgId?: string; orgSlug?: string } = {}) {
+  let targetOrgId = options.orgId ?? session.orgId;
+
+  if (options.orgSlug) {
+    const org = await prisma.org.findUnique({
+      where: { slug: options.orgSlug },
+      select: { id: true },
+    });
+
+    if (!org) {
+      return null;
+    }
+
+    targetOrgId = org.id;
+  }
+
+  if (targetOrgId) {
+    return prisma.orgMembership.findFirst({
+      where: { userId: session.sub, orgId: targetOrgId },
+      include: { org: true },
+    });
+  }
+
+  return prisma.orgMembership.findFirst({
+    where: { userId: session.sub },
+    include: { org: true },
+    orderBy: { createdAt: 'asc' },
+  });
+}
+
+export async function getRequestContext(request: NextRequest): Promise<RequestContext | null> {
+  const session = getSessionData(request);
   if (!session) return null;
 
-  // Prefer the orgId from the session context, fallback to earliest membership if missing.
-  const membership = session.orgId
-    ? await prisma.orgMembership.findFirst({
-        where: { userId: session.sub, orgId: session.orgId },
-        include: { org: true },
-      })
-    : await prisma.orgMembership.findFirst({
-        where: { userId: session.sub },
-        include: { org: true },
-        orderBy: { createdAt: 'asc' },
-      });
-
+  const membership = await resolveMembership(session);
   if (!membership) return null;
 
   return {
@@ -39,6 +75,34 @@ export async function getRequestContext(request: NextRequest): Promise<RequestCo
     roles: [membership.role],
     session,
   };
+}
+
+export async function getOrgRequestContext(
+  request: NextRequest,
+  options: { orgId?: string; orgSlug?: string } = {}
+): Promise<OrgRequestContext | null> {
+  const session = getSessionData(request);
+  if (!session) return null;
+
+  const membership = await resolveMembership(session, options);
+  if (!membership) return null;
+
+  return {
+    userId: session.sub,
+    orgId: membership.org.id,
+    orgSlug: membership.org.slug,
+    roles: [membership.role],
+    billingTier: membership.org.billingTier,
+    billingStatus: membership.org.billingStatus,
+    session,
+  };
+}
+
+export function isOrgBillingRestricted(org: {
+  billingTier?: string | null;
+  billingStatus?: string | null;
+}): boolean {
+  return org.billingTier === 'restricted' || org.billingStatus === 'canceled';
 }
 
 export async function requireAuth(request: NextRequest): Promise<RequestContext> {
@@ -58,6 +122,23 @@ export async function requireRole(request: NextRequest, requiredRole: string): P
 
   if (userRoleIndex < requiredRoleIndex) {
     throw new Error(`Role ${requiredRole} required`);
+  }
+
+  return context;
+}
+
+export async function requireOrgBillingAccess(
+  request: NextRequest,
+  options: { orgId?: string; orgSlug?: string } = {}
+): Promise<OrgRequestContext> {
+  const context = await getOrgRequestContext(request, options);
+
+  if (!context) {
+    throw new Error('Authentication required');
+  }
+
+  if (isOrgBillingRestricted(context)) {
+    throw new BillingRestrictionError();
   }
 
   return context;

--- a/apps/platform/lib/user-context.tsx
+++ b/apps/platform/lib/user-context.tsx
@@ -22,6 +22,8 @@ interface Organization {
   name: string;
   slug: string;
   role: string;
+  billingTier?: string;
+  billingStatus?: string;
 }
 
 interface UserContextType {

--- a/apps/platform/middleware.ts
+++ b/apps/platform/middleware.ts
@@ -1,42 +1,102 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export default function middleware(req: NextRequest) {
+const INTERNAL_ACCESS_PATH = "/api/v1/internal/org-access";
+const BILLING_RECOVERY_PATHS = new Set([
+  "/api/billing/checkout",
+  "/api/v1/billing/checkout",
+  "/api/billing/webhook",
+  "/api/v1/billing/webhook",
+  "/api/v1/orgs/active",
+  "/api/v1/orgs/join",
+  "/api/v1/profile",
+]);
+const PUBLIC_PATH_PREFIXES = ["/auth", "/onboarding", "/_next/"];
+
+function applyCors(response: Response) {
+  response.headers.set('Access-Control-Allow-Origin', '*');
+  response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
+  response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+  response.headers.set('Access-Control-Max-Age', '86400');
+  return response;
+}
+
+function isPublicPath(pathname: string) {
+  return (
+    pathname === "/" ||
+    PUBLIC_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    pathname.includes(".")
+  );
+}
+
+function extractOrgSlug(pathname: string) {
+  const match = pathname.match(/^\/o\/([^/]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function isStateChangingMethod(method: string) {
+  return method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+}
+
+async function fetchOrgAccess(req: NextRequest, orgSlug?: string | null) {
+  const url = new URL(INTERNAL_ACCESS_PATH, req.url);
+  if (orgSlug) {
+    url.searchParams.set('slug', orgSlug);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      cookie: req.headers.get('cookie') ?? '',
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return response.json() as Promise<{ restricted: boolean }>;
+}
+
+export default async function middleware(req: NextRequest) {
   const { nextUrl } = req;
 
   // Handle CORS for API routes
   if (nextUrl.pathname.startsWith("/api/")) {
-    // Handle preflight requests
-    if (req.method === 'OPTIONS') {
-      return new Response(null, {
-        status: 200,
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
-          'Access-Control-Max-Age': '86400',
-        },
-      });
+    if (nextUrl.pathname === INTERNAL_ACCESS_PATH) {
+      return applyCors(NextResponse.next());
     }
 
-    // Add CORS headers to all API responses
-    const response = NextResponse.next();
-    response.headers.set('Access-Control-Allow-Origin', '*');
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
-    response.headers.set('Access-Control-Max-Age', '86400');
-    return response;
+    // Handle preflight requests
+    if (req.method === 'OPTIONS') {
+      return applyCors(new Response(null, {
+        status: 200,
+      }));
+    }
+
+    if (
+      req.cookies.get('session')?.value &&
+      isStateChangingMethod(req.method) &&
+      !BILLING_RECOVERY_PATHS.has(nextUrl.pathname) &&
+      !nextUrl.pathname.startsWith('/api/v1/auth/')
+    ) {
+      const access = await fetchOrgAccess(req);
+
+      if (access?.restricted) {
+        return applyCors(
+          NextResponse.json(
+            { error: 'Organization access is restricted until billing is restored' },
+            { status: 402 }
+          )
+        );
+      }
+    }
+
+    return applyCors(NextResponse.next());
   }
 
   // Allow access to public routes, API routes, and auth pages
-  if (
-    nextUrl.pathname === "/" ||
-    nextUrl.pathname.startsWith("/api/") ||
-    nextUrl.pathname.startsWith("/auth") ||
-    nextUrl.pathname.startsWith("/onboarding") ||
-    nextUrl.pathname.startsWith("/_next/") ||
-    nextUrl.pathname.includes(".") // Static files
-  ) {
+  if (isPublicPath(nextUrl.pathname)) {
     return NextResponse.next();
   }
 
@@ -47,6 +107,19 @@ export default function middleware(req: NextRequest) {
     if (!sessionToken) {
       // No session, redirect to login
       return NextResponse.redirect(new URL('/auth/login', req.url));
+    }
+
+    const orgSlug = extractOrgSlug(nextUrl.pathname);
+    const isPricingRoute = orgSlug ? nextUrl.pathname === `/o/${orgSlug}/pricing` : false;
+
+    if (orgSlug && !isPricingRoute) {
+      const access = await fetchOrgAccess(req, orgSlug);
+
+      if (access?.restricted) {
+        const pricingUrl = new URL(`/o/${orgSlug}/pricing`, req.url);
+        pricingUrl.searchParams.set('billing', 'restricted');
+        return NextResponse.redirect(pricingUrl);
+      }
     }
   }
 

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -59,6 +59,7 @@
     "sharp": "^0.34.5",
     "speakeasy": "^2.0.0",
     "stream-browserify": "^3.0.0",
+    "stripe": "^22.0.2",
     "tailwind-merge": "^3.3.1",
     "tesseract.js": "^7.0.0",
     "util": "^0.12.5",

--- a/packages/db/migrations/20260420133500_add_org_billing_fields/migration.sql
+++ b/packages/db/migrations/20260420133500_add_org_billing_fields/migration.sql
@@ -1,0 +1,9 @@
+-- Add self-serve billing state to organizations
+ALTER TABLE "Org"
+  ADD COLUMN "billing_tier" TEXT NOT NULL DEFAULT 'free',
+  ADD COLUMN "billing_status" TEXT NOT NULL DEFAULT 'inactive',
+  ADD COLUMN "stripe_customer_id" TEXT,
+  ADD COLUMN "stripe_subscription_id" TEXT;
+
+CREATE UNIQUE INDEX "Org_stripe_customer_id_key" ON "Org"("stripe_customer_id");
+CREATE UNIQUE INDEX "Org_stripe_subscription_id_key" ON "Org"("stripe_subscription_id");

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -16,6 +16,10 @@ model Org {
   slug                 String                @unique
   createdAt            DateTime              @default(now())
   updatedAt            DateTime              @updatedAt
+  billingTier          String                @default("free") @map("billing_tier")
+  billingStatus        String                @default("inactive") @map("billing_status")
+  stripeCustomerId     String?               @unique @map("stripe_customer_id")
+  stripeSubscriptionId String?               @unique @map("stripe_subscription_id")
   // Budget configuration
   budgetEnabled        Boolean               @default(true)
   budgetOnError        String                @default("block") // "block" | "pass"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
+      stripe:
+        specifier: ^22.0.2
+        version: 22.0.2(@types/node@22.16.5)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -4841,6 +4844,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.0.2:
+    resolution: {integrity: sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -10272,6 +10284,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.0.2(@types/node@22.16.5):
+    optionalDependencies:
+      '@types/node': 22.16.5
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add Stripe-backed checkout and webhook routes for self-serve Starter and Growth billing
- add pricing UI, org billing persistence, env placeholders, and billing-focused API tests
- add org billing fields plus Prisma migration for Stripe customer/subscription state

## GovernsAI Tracker issue
a280b8bf-6487-4267-aae5-ca196d91cdec

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] pnpm --filter @governs-ai/platform exec jest __tests__/api/billing-checkout.test.ts __tests__/api/billing-webhook.test.ts
- [ ] Stripe test-mode checkout end to end with real STRIPE_* secrets and a live DATABASE_URL
- [ ] pnpm --filter @governs-ai/platform build (currently blocked by unrelated existing build-time env/import issues in OCR and OpenAI routes)