### PR TITLE
feat(ci): Wire E2E job into dashboard GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,15 +163,3 @@ jobs:
             apps/platform/playwright-report
             apps/platform/test-results
           retention-days: 7
-
-  secret-scan:
-    name: Secret Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Deploy to Vercel
         id: deploy_step
         run: |
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)
           echo "url=$url" >> $GITHUB_OUTPUT
 
   e2e-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,41 +104,41 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci_db
 
   deploy:
-    name: Deploy to Vercel
+    name: Deploy to Vercel (Preview)
     runs-on: ubuntu-latest
     needs: build
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     outputs:
       url: ${{ steps.deploy_step.outputs.url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel Environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Build Vercel Output
-        run: pnpm build --filter @governs-ai/platform # Build specifically for Vercel deployment
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Deploy to Vercel
-        uses: BetaHuhn/deploy-to-vercel-action@v1.9.0
         id: deploy_step
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prebuilt --yes' # Use --prebuilt since build job already runs
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> $GITHUB_OUTPUT
 
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: deploy
     env:
-      PLAYWRIGHT_BASE_URL: ${{needs.deploy.outputs.url}}
+      PLAYWRIGHT_BASE_URL: ${{ needs.deploy.outputs.url }}
       TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
       TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      E2E_TEST_ORG_SLUG: ${{ vars.E2E_TEST_ORG_SLUG }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -151,14 +151,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: pnpm --filter @governs-ai/platform exec playwright install --with-deps chromium
       - name: Run E2E Tests
         run: pnpm --filter @governs-ai/platform test:e2e
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            apps/platform/playwright-report
+            apps/platform/test-results
+          retention-days: 7
 
   secret-scan:
     name: Secret Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,72 @@ jobs:
         run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci_db
+
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      url: ${{ steps.deploy_step.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build Vercel Output
+        run: pnpm build --filter @governs-ai/platform # Build specifically for Vercel deployment
+      - name: Deploy to Vercel
+        uses: BetaHuhn/deploy-to-vercel-action@v1.9.0
+        id: deploy_step
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prebuilt --yes' # Use --prebuilt since build job already runs
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    env:
+      PLAYWRIGHT_BASE_URL: ${{needs.deploy.outputs.url}}
+      TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E Tests
+        run: pnpm --filter @governs-ai/platform test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Added `deploy` job to deploy the application to Vercel and retrieve the preview URL.
- Added `e2e-tests` job to run Playwright E2E tests against the Vercel preview deployment.
- Updated CI trigger to `dev` branch for push and pull requests.

## GovernsAI Tracker issue
GOV-467 (b5b53d6f-c28a-4f56-8181-5c9f65bcdf5b)

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [ ] Verify that the CI workflow runs on PRs to `dev`.
- [ ] Verify that the `deploy` job successfully deploys to Vercel and outputs a preview URL.
- [ ] Verify that the `e2e-tests` job runs after `deploy` and uses the preview URL.
- [ ] Verify that `playwright-report` artifact is uploaded on failure.
- [ ] Verify the following GitHub secrets are configured in the `governsai-console` repository:
    *   `VERCEL_TOKEN`
    *   `VERCEL_ORG_ID`
    *   `VERCEL_PROJECT_ID`
    *   `TEST_USER_EMAIL`
    *   `TEST_USER_PASSWORD`