### PR TITLE
feat(platform): add stable dashboard test ids

### DIFF
--- a/apps/platform/app/auth/login/page.tsx
+++ b/apps/platform/app/auth/login/page.tsx
@@ -62,19 +62,23 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex items-center justify-center p-4">
+    <div
+      className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex items-center justify-center p-4"
+      data-testid="login-page"
+    >
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
           <p className="text-gray-600">Sign in to your GovernsAI account</p>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4" data-testid="login-form">
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
                 Email
               </label>
               <Input
+                data-testid="email-input"
                 id="email"
                 type="email"
                 value={email}
@@ -90,6 +94,7 @@ export default function LoginPage() {
                 Password
               </label>
               <Input
+                data-testid="password-input"
                 id="password"
                 type="password"
                 value={password}
@@ -106,6 +111,7 @@ export default function LoginPage() {
                   Authentication Code
                 </label>
                 <Input
+                  data-testid="totp-code-input"
                   id="totpCode"
                   type="text"
                   value={totpCode}
@@ -122,12 +128,13 @@ export default function LoginPage() {
             )}
 
             {error && (
-              <div className="text-red-600 text-sm bg-red-50 p-3 rounded-md">
+              <div className="text-red-600 text-sm bg-red-50 p-3 rounded-md" data-testid="login-error-state">
                 {error}
               </div>
             )}
 
             <Button
+              data-testid="login-submit-button"
               type="submit"
               className="w-full"
               disabled={loading}

--- a/apps/platform/app/loading.tsx
+++ b/apps/platform/app/loading.tsx
@@ -2,7 +2,10 @@ import { LoadingSpinner } from "@governs-ai/ui"
 
 export default function Loading() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex items-center justify-center">
+    <div
+      className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex items-center justify-center"
+      data-testid="platform-loading-state"
+    >
       <div className="text-center">
         <LoadingSpinner size="lg" className="mx-auto mb-4" />
         <p className="text-gray-600">Loading GovernsAI...</p>

--- a/apps/platform/app/o/[slug]/decisions/page.tsx
+++ b/apps/platform/app/o/[slug]/decisions/page.tsx
@@ -188,7 +188,7 @@ export default function DecisionsPage() {
   if (!orgLoading && !org) {
     return (
       <PlatformShell orgSlug={orgSlug}>
-        <div className="flex items-center justify-center h-64">
+        <div className="flex items-center justify-center h-64" data-testid="decisions-org-not-found-state">
           <p className="text-muted-foreground">Organization not found.</p>
         </div>
       </PlatformShell>
@@ -198,7 +198,7 @@ export default function DecisionsPage() {
   if (loading) {
     return (
       <PlatformShell orgSlug={orgSlug}>
-        <div className="flex items-center justify-center h-64">
+        <div className="flex items-center justify-center h-64" data-testid="decisions-loading-state">
           <LoadingSpinner size="lg" />
         </div>
       </PlatformShell>
@@ -207,7 +207,7 @@ export default function DecisionsPage() {
 
   return (
     <PlatformShell orgSlug={orgSlug}>
-      <div className="space-y-6">
+      <div className="space-y-6" data-testid="decisions-page">
         <PageHeader
           title="AI Governance Decisions"
           subtitle={`Monitor all AI governance decisions (precheck/postcheck) including tool calls, model usage, and policy enforcement for ${orgSlug}`}
@@ -295,7 +295,7 @@ export default function DecisionsPage() {
         {/* Decisions Content */}
         <div className="space-y-4">
             {/* Search and Filters */}
-            <div className="flex gap-4 items-center">
+            <div className="flex gap-4 items-center" data-testid="decisions-filter-controls">
               <div className="flex-1">
                 <input
                   type="text"
@@ -303,6 +303,7 @@ export default function DecisionsPage() {
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="decisions-search-input"
                 />
               </div>
               <div className="flex gap-2">
@@ -310,6 +311,7 @@ export default function DecisionsPage() {
                   value={filters.direction}
                   onChange={(e) => setFilters(prev => ({ ...prev, direction: e.target.value }))}
                   className="px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="decisions-direction-filter"
                 >
                   <option value="">All Directions</option>
                   <option value="precheck">Pre-check</option>
@@ -319,6 +321,7 @@ export default function DecisionsPage() {
                   value={filters.decision}
                   onChange={(e) => setFilters(prev => ({ ...prev, decision: e.target.value }))}
                   className="px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="decisions-outcome-filter"
                 >
                   <option value="">All Decisions</option>
                   <option value="allow">Allow</option>
@@ -329,7 +332,7 @@ export default function DecisionsPage() {
             </div>
 
             {filteredDecisions.length === 0 ? (
-              <Card>
+              <Card data-testid="decisions-empty-state">
                 <CardContent className="p-8 text-center">
                   <Activity className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                   <h3 className="text-lg font-medium mb-2">No Decisions Found</h3>
@@ -339,7 +342,7 @@ export default function DecisionsPage() {
                 </CardContent>
               </Card>
             ) : (
-              <div className="border rounded-lg overflow-hidden">
+              <div className="border rounded-lg overflow-hidden" data-testid="decisions-table">
                 <table className="w-full">
                   <thead className="bg-muted/50">
                     <tr>
@@ -354,7 +357,7 @@ export default function DecisionsPage() {
                   <tbody className="divide-y divide-border">
                     {filteredDecisions.map((decision) => (
                       <React.Fragment key={decision.id}>
-                        <tr className="hover:bg-muted/30">
+                        <tr className="hover:bg-muted/30" data-testid={`decision-row-${decision.id}`}>
                           <td className="px-4 py-3">
                             {getDecisionBadge(decision.decision)}
                           </td>
@@ -374,6 +377,8 @@ export default function DecisionsPage() {
                             <button
                               onClick={() => toggleExpanded(decision.id)}
                               className="p-1 hover:bg-muted rounded"
+                              data-testid={`decision-details-button-${decision.id}`}
+                              aria-label={`Toggle details for decision ${decision.id}`}
                             >
                               {expandedDecisions.has(decision.id) ? (
                                 <ChevronUp className="h-4 w-4" />

--- a/apps/platform/app/o/[slug]/keys/page.tsx
+++ b/apps/platform/app/o/[slug]/keys/page.tsx
@@ -192,7 +192,10 @@ export default function KeysPage() {
   if (loading && apiKeys.length === 0) {
     return (
       <PlatformShell orgSlug={orgSlug}>
-        <div className="min-h-screen bg-background flex items-center justify-center">
+        <div
+          className="min-h-screen bg-background flex items-center justify-center"
+          data-testid="api-keys-loading-state"
+        >
           <div className="text-center">
             <LoadingSpinner size="lg" className="mx-auto mb-4" />
             <p className="text-muted-foreground">Loading API keys...</p>
@@ -208,7 +211,7 @@ export default function KeysPage() {
   return (
     <PlatformShell orgSlug={orgSlug}>
       <RoleGuard requiredPermission="canManageKeys">
-        <div className="space-y-6">
+        <div className="space-y-6" data-testid="api-keys-page">
         {/* Removed legacy precheck banner; success info shown below */}
         <PageHeader
           title="API Keys"
@@ -216,6 +219,7 @@ export default function KeysPage() {
           actions={
             canManageKeys() && (
               <Button
+                data-testid="create-key-button"
                 onClick={() => setShowCreateForm(!showCreateForm)}
                 variant="outline"
               >
@@ -228,7 +232,7 @@ export default function KeysPage() {
 
         {/* Precheck Integration Info - Only show when user creates their first API key */}
         {showIntegrationInfo && newFullKey && newKeyName && (
-          <Card className="border-green-200 bg-green-50">
+          <Card className="border-green-200 bg-green-50" data-testid="api-key-created-state">
             <CardHeader>
               <CardTitle className="flex items-center justify-between text-green-800">
                 <div className="flex items-center gap-2">
@@ -289,7 +293,10 @@ export default function KeysPage() {
                 <div className="space-y-2">
                   <div className="text-sm font-medium">Your New API Key</div>
                   <div className="flex items-center gap-2">
-                    <code className="inline-block break-all rounded bg-muted px-2 py-1 text-sm">
+                    <code
+                      className="inline-block break-all rounded bg-muted px-2 py-1 text-sm"
+                      data-testid="api-key-preview-display"
+                    >
                       {newFullKey}
                     </code>
                     <Button
@@ -331,7 +338,7 @@ export default function KeysPage() {
 
         {/* Create Form */}
         {showCreateForm && (
-          <Card>
+          <Card data-testid="create-key-form">
             <CardHeader>
               <CardTitle>Create New API Key</CardTitle>
             </CardHeader>
@@ -340,6 +347,7 @@ export default function KeysPage() {
                 <div>
                   <label className="block text-sm font-medium mb-1">Key Name</label>
                   <Input
+                    data-testid="api-key-name-input"
                     value={formData.name}
                     onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
                     placeholder="My API Key"
@@ -369,7 +377,7 @@ export default function KeysPage() {
                   </div>
                 </div>
                 <div className="flex gap-2">
-                  <Button type="submit" disabled={loading}>
+                  <Button type="submit" disabled={loading} data-testid="create-key-submit-button">
                     {loading ? 'Creating...' : 'Create Key'}
                   </Button>
                   <Button
@@ -387,7 +395,10 @@ export default function KeysPage() {
 
         {/* Error Message */}
         {error && (
-          <div className="bg-destructive/10 border border-destructive/20 text-destructive p-4 rounded-md">
+          <div
+            className="bg-destructive/10 border border-destructive/20 text-destructive p-4 rounded-md"
+            data-testid="api-keys-error-state"
+          >
             {error}
           </div>
         )}
@@ -401,7 +412,7 @@ export default function KeysPage() {
             </div>
           </div>
           
-          <DataTable>
+          <DataTable data-testid="api-key-table">
             <DataTableHeader>
               <DataTableRow>
                 <DataTableHead>Name</DataTableHead>
@@ -414,7 +425,7 @@ export default function KeysPage() {
             </DataTableHeader>
             <DataTableBody>
               {apiKeys.map((key) => (
-                <DataTableRow key={key.id}>
+                <DataTableRow key={key.id} data-testid={`api-key-row-${key.id}`}>
                   <DataTableCell>
                     <div className="flex items-center gap-2">
                       <Key className="h-4 w-4 text-muted-foreground" />
@@ -455,6 +466,8 @@ export default function KeysPage() {
                           size="icon"
                           className="h-8 w-8"
                           onClick={() => handleToggleKey(key.id, !key.isActive)}
+                          data-testid={`toggle-key-button-${key.id}`}
+                          aria-label={`${key.isActive ? 'Deactivate' : 'Activate'} API key ${key.name}`}
                         >
                           <Shield className="h-4 w-4" />
                         </Button>
@@ -463,6 +476,8 @@ export default function KeysPage() {
                           size="icon"
                           className="h-8 w-8"
                           onClick={() => handleDeleteKey(key.id)}
+                          data-testid={`revoke-key-button-${key.id}`}
+                          aria-label={`Revoke API key ${key.name}`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>

--- a/apps/platform/components/platform-shell.tsx
+++ b/apps/platform/components/platform-shell.tsx
@@ -201,10 +201,13 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Sidebar */}
-      <aside className={cn(
-        "fixed left-0 top-0 h-full w-64 border-r border-border bg-card/70 backdrop-blur transition-transform duration-150 ease-pleasant",
-        sidebarExpanded ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
-      )}>
+      <aside
+        className={cn(
+          "fixed left-0 top-0 h-full w-64 border-r border-border bg-card/70 backdrop-blur transition-transform duration-150 ease-pleasant",
+          sidebarExpanded ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
+        )}
+        data-testid="nav-sidebar"
+      >
         <div className="flex h-full flex-col">
           {/* Logo */}
           <div className="flex h-16 items-center border-b border-border px-4">
@@ -263,6 +266,8 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
                   size="icon"
                   className="h-8 w-8"
                   onClick={() => setUserMenuOpen(!userMenuOpen)}
+                  data-testid="user-menu-button"
+                  aria-label="Open user menu"
                 >
                   <MoreVertical className="h-4 w-4" />
                 </Button>
@@ -271,6 +276,7 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
                   <div 
                     className="absolute bottom-full right-0 mb-2 w-48 bg-card border border-border rounded-md shadow-lg z-50"
                     onClick={(e) => e.stopPropagation()}
+                    data-testid="user-menu"
                   >
                     <div className="py-1">
                       <button
@@ -403,9 +409,12 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
         </header>
 
         {/* Main content area */}
-        <main className="p-6">
+        <main className="p-6" data-testid="platform-main-content">
           {isOrgMismatch ? (
-            <div className="flex items-center justify-center min-h-[60vh]">
+            <div
+              className="flex items-center justify-center min-h-[60vh]"
+              data-testid={orgSyncState === 'error' ? 'org-switch-error-state' : 'org-switch-loading-state'}
+            >
               {orgSyncState === 'error' ? (
                 <div className="text-center space-y-3">
                   <p className="text-sm text-muted-foreground">
@@ -442,6 +451,7 @@ export default function PlatformShell({ children, orgSlug = 'acme-inc' }: Platfo
         <div
           className="fixed inset-0 z-30 bg-background/80 backdrop-blur-sm lg:hidden"
           onClick={() => setSidebarExpanded(false)}
+          data-testid="mobile-sidebar-overlay"
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add stable data-testid hooks to the login page, platform shell, API keys page, and decisions page
- cover key loading and empty states used by Nova's Playwright flow
- keep selector names descriptive and kebab-case for E2E stability

## GovernsAI Tracker issue
81e39108-ee4a-446b-988b-cd5ec62aacf7

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] pnpm lint
- [x] pnpm --filter @governs-ai/platform exec tsc --noEmit
- [x] pnpm --filter @governs-ai/platform exec jest __tests__/api/keys.test.ts --runInBand
- [ ] pnpm --filter @governs-ai/platform build (local build blocked by required env vars like JWT_SECRET/PASSWORD_PEPPER/OPENAI_API_KEY/WEBHOOK_SECRET and a pre-existing pdf-parse import warning in ocr-service.ts)