### PR TITLE
ci(secret-scan): re-introduce gitleaks via pinned CLI binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,37 @@ jobs:
         run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci_db
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    # Gitleaks CLI binary from the MIT-licensed upstream project.
+    # Pinned to release v8.30.1 (commit 83d9cd684c87d95d656c1458ef04895a7f1cbd8e).
+    # Bump deliberately: update GITLEAKS_VERSION, GITLEAKS_COMMIT_SHA, and GITLEAKS_SHA256.
+    env:
+      GITLEAKS_VERSION: "8.30.1"
+      GITLEAKS_COMMIT_SHA: "83d9cd684c87d95d656c1458ef04895a7f1cbd8e"
+      GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks (pinned)
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+
+          curl --fail --silent --show-error --location --retry 3 --output "${archive}" "${url}"
+
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check --status
+
+          tar -xzf "${archive}" gitleaks
+          install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f "${archive}" gitleaks
+
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --source=. --redact --verbose --no-banner --exit-code=1


### PR DESCRIPTION
## Summary
- Restores secret scanning in `.github/workflows/ci.yml` as a blocking job (no `continue-on-error`).
- Drops `gitleaks/gitleaks-action@v2` (paid `GITLEAKS_LICENSE` requirement) in favor of the MIT-licensed gitleaks CLI binary.
- Binary pinned to **v8.30.1** (upstream commit `83d9cd684c87d95d656c1458ef04895a7f1cbd8e`) and checksum-verified against the published release SHA-256 (`551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb`).
- Runs on every PR and push to `[main, dev]`; `gitleaks detect --exit-code=1` fails the pipeline on any finding.

## GovernsAI Tracker issue
GOV-551 (b56245e1-dad7-427f-a99b-63a4d6da9f90)
Follow-up from GOV-467 (b5b53d6f-c28a-4f56-8181-5c9f65bcdf5b)

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [ ] CI `Secret Scan` job runs on this PR and completes with exit 0 (no leaks in repo).
- [ ] Job appears on `push` to `dev` and `main` as well (verified via workflow `on:` keys).
- [ ] `curl ... | sha256sum --check` passes for the pinned linux_x64 tarball.
- [ ] Introducing a fake leak locally (e.g. `AKIA...`) causes `gitleaks detect --exit-code=1` to return non-zero (spot-check).
- [ ] No reliance on a `GITLEAKS_LICENSE` secret.

## Bump procedure
To upgrade gitleaks in the future, update these three values in the `secret-scan` job in one commit:
- `GITLEAKS_VERSION`
- `GITLEAKS_COMMIT_SHA` (from `gh api repos/gitleaks/gitleaks/git/refs/tags/v<version>`)
- `GITLEAKS_SHA256` (linux_x64 row from the release's `checksums.txt`)