### PR TITLE
chore(changelog): scaffold CHANGELOG.md for Arbiter releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
## Summary
- Creates an empty Keep-a-Changelog scaffold at `CHANGELOG.md` so Quill can prepend the first `[v<semver>]` entry after Arbiter's next release.
- Part of the Arbiter→Quill CHANGELOG chain verification before tomorrow 2026-04-24 02:00 UTC.

## GovernsAI Tracker issue
[GOV-562](mention://issue/d8b14072-7122-4635-bb81-acddbfd518db)

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [ ] File exists at repo root as `CHANGELOG.md`.
- [ ] Format follows Keep a Changelog 1.1.0 with an `[Unreleased]` section.