### PR TITLE
feat(platform): audit log filtering API + UI (GOV-586)

### DIFF
--- a/apps/platform/__mocks__/prisma.ts
+++ b/apps/platform/__mocks__/prisma.ts
@@ -32,6 +32,8 @@ export const prisma = {
   },
   decision: {
     create: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
   },
   usageRecord_: jest.fn(),
   mfaTotp: {

--- a/apps/platform/__tests__/api/audit.test.ts
+++ b/apps/platform/__tests__/api/audit.test.ts
@@ -1,0 +1,184 @@
+/**
+ * TEST-2.2a — Dashboard audit log filter API (GOV-586).
+ *
+ * Covers:
+ *  - 401 when unauthenticated
+ *  - filter by decision type returns only matching events
+ *  - time range (`from`/`to`) is passed to Prisma as gte/lte bounds
+ *  - filtered query results match the Prisma response (integration-style)
+ *  - pagination limit/offset and hasMore
+ *  - validation: invalid `decision`, inverted time range
+ *  - orgId is always sourced from the authenticated context
+ */
+
+import { NextRequest } from 'next/server';
+import { prisma } from '@governs-ai/db';
+
+jest.mock('@/lib/session', () => ({
+  requireAuth: jest.fn(),
+}));
+
+import { requireAuth } from '@/lib/session';
+import { GET } from '@/app/api/v1/audit/route';
+
+const mockAuth = requireAuth as jest.Mock;
+const mockPrisma = prisma as any;
+
+const AUTH_CTX = {
+  orgId: 'org-1',
+  userId: 'user-1',
+  roles: ['OWNER'],
+  orgSlug: 'org',
+  session: {},
+};
+
+function makeReq(url: string) {
+  return new NextRequest(url, { method: 'GET' });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuth.mockResolvedValue(AUTH_CTX);
+  mockPrisma.decision.findMany.mockResolvedValue([]);
+  mockPrisma.decision.count.mockResolvedValue(0);
+});
+
+describe('GET /api/v1/audit — auth', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockAuth.mockRejectedValueOnce(new Error('Authentication required'));
+    const res = await GET(makeReq('http://localhost/api/v1/audit'));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('always scopes to the authenticated orgId, ignoring any query-string orgId', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit?orgId=other-org'));
+    expect(res.status).toBe(200);
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.orgId).toBe('org-1');
+  });
+});
+
+describe('GET /api/v1/audit — filters', () => {
+  it('filter by decision type returns only matching events', async () => {
+    const denyEvents = [
+      { id: 'd1', orgId: 'org-1', decision: 'deny', tool: 'search_web', ts: new Date() },
+      { id: 'd2', orgId: 'org-1', decision: 'deny', tool: 'search_web', ts: new Date() },
+    ];
+    mockPrisma.decision.findMany.mockResolvedValueOnce(denyEvents);
+    mockPrisma.decision.count.mockResolvedValueOnce(2);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit?decision=deny'));
+    expect(res.status).toBe(200);
+
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.decision).toBe('deny');
+
+    const body = await res.json();
+    expect(body.events).toHaveLength(2);
+    expect(body.events.every((e: any) => e.decision === 'deny')).toBe(true);
+  });
+
+  it('rejects an invalid decision value with 400', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit?decision=maybe'));
+    expect(res.status).toBe(400);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('passes `from`/`to` to Prisma as gte/lte bounds on ts', async () => {
+    const from = '2026-01-01T00:00:00.000Z';
+    const to = '2026-01-31T23:59:59.000Z';
+    const res = await GET(makeReq(`http://localhost/api/v1/audit?from=${from}&to=${to}`));
+    expect(res.status).toBe(200);
+
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.ts.gte.toISOString()).toBe(from);
+    expect(where.ts.lte.toISOString()).toBe(to);
+  });
+
+  it('returns 400 when `from` is after `to`', async () => {
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit?from=2026-02-01T00:00:00Z&to=2026-01-01T00:00:00Z'),
+    );
+    expect(res.status).toBe(400);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('filters by tool and maps `user` to correlationId', async () => {
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit?tool=search_web&user=corr-abc'),
+    );
+    expect(res.status).toBe(200);
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.tool).toBe('search_web');
+    expect(where.correlationId).toBe('corr-abc');
+  });
+
+  it('ignores malformed date values (treats them as absent)', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit?from=not-a-date'));
+    expect(res.status).toBe(200);
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.ts).toBeUndefined();
+  });
+});
+
+describe('GET /api/v1/audit — integration: filtered results match Prisma response', () => {
+  it('returns exactly the events Prisma produces and a matching total count', async () => {
+    const dbRows = [
+      { id: 'a', orgId: 'org-1', decision: 'allow', tool: 'x', ts: new Date('2026-03-01') },
+      { id: 'b', orgId: 'org-1', decision: 'allow', tool: 'y', ts: new Date('2026-03-02') },
+      { id: 'c', orgId: 'org-1', decision: 'allow', tool: 'z', ts: new Date('2026-03-03') },
+    ];
+    mockPrisma.decision.findMany.mockResolvedValueOnce(dbRows);
+    mockPrisma.decision.count.mockResolvedValueOnce(3);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit?decision=allow'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.events).toHaveLength(dbRows.length);
+    expect(body.events.map((e: any) => e.id)).toEqual(dbRows.map((r) => r.id));
+    expect(body.pagination.total).toBe(3);
+
+    // findMany and count must see the same where clause so totals match the list
+    const listWhere = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    const countWhere = mockPrisma.decision.count.mock.calls[0][0].where;
+    expect(countWhere).toEqual(listWhere);
+  });
+});
+
+describe('GET /api/v1/audit — pagination', () => {
+  it('applies limit and offset and reports hasMore', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce(
+      Array.from({ length: 10 }, (_, i) => ({ id: `e${i}`, orgId: 'org-1' })),
+    );
+    mockPrisma.decision.count.mockResolvedValueOnce(25);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit?limit=10&offset=10'));
+    expect(res.status).toBe(200);
+
+    const call = mockPrisma.decision.findMany.mock.calls[0][0];
+    expect(call.take).toBe(10);
+    expect(call.skip).toBe(10);
+
+    const body = await res.json();
+    expect(body.pagination).toMatchObject({ limit: 10, offset: 10, total: 25, hasMore: true });
+  });
+
+  it('reports hasMore=false on the final page', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce(
+      Array.from({ length: 5 }, (_, i) => ({ id: `e${i}` })),
+    );
+    mockPrisma.decision.count.mockResolvedValueOnce(25);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit?limit=10&offset=20'));
+    const body = await res.json();
+    expect(body.pagination.hasMore).toBe(false);
+  });
+
+  it('caps limit at 500 to prevent runaway queries', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit?limit=99999'));
+    expect(res.status).toBe(200);
+    expect(mockPrisma.decision.findMany.mock.calls[0][0].take).toBe(500);
+  });
+});

--- a/apps/platform/app/api/v1/audit/route.ts
+++ b/apps/platform/app/api/v1/audit/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@governs-ai/db';
+import { requireAuth } from '@/lib/session';
+
+const ALLOWED_DECISIONS = ['allow', 'transform', 'deny'] as const;
+const MAX_LIMIT = 500;
+const DEFAULT_LIMIT = 50;
+
+function parseIntParam(raw: string | null, fallback: number, { min = 0, max }: { min?: number; max?: number } = {}): number {
+  if (raw === null || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  let value = parsed;
+  if (typeof min === 'number' && value < min) value = min;
+  if (typeof max === 'number' && value > max) value = max;
+  return value;
+}
+
+function parseDateParam(raw: string | null): Date | undefined {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+export async function GET(request: NextRequest) {
+  let orgId: string;
+  try {
+    ({ orgId } = await requireAuth(request));
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+
+  const decision = searchParams.get('decision');
+  const tool = searchParams.get('tool');
+  const user = searchParams.get('user');
+  const from = parseDateParam(searchParams.get('from'));
+  const to = parseDateParam(searchParams.get('to'));
+  const limit = parseIntParam(searchParams.get('limit'), DEFAULT_LIMIT, { min: 1, max: MAX_LIMIT });
+  const offset = parseIntParam(searchParams.get('offset'), 0, { min: 0 });
+
+  if (decision && !ALLOWED_DECISIONS.includes(decision as (typeof ALLOWED_DECISIONS)[number])) {
+    return NextResponse.json(
+      { error: `Invalid decision filter. Allowed: ${ALLOWED_DECISIONS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  if (from && to && from > to) {
+    return NextResponse.json({ error: '`from` must be earlier than `to`' }, { status: 400 });
+  }
+
+  const where: Record<string, unknown> = { orgId };
+  if (decision) where.decision = decision;
+  if (tool) where.tool = tool;
+  // Decision has no userId column; `user` maps to correlationId, the closest
+  // available per-request identity marker. See GOV-586.
+  if (user) where.correlationId = user;
+  if (from || to) {
+    const ts: Record<string, Date> = {};
+    if (from) ts.gte = from;
+    if (to) ts.lte = to;
+    where.ts = ts;
+  }
+
+  const [events, total] = await Promise.all([
+    prisma.decision.findMany({
+      where,
+      orderBy: { ts: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.decision.count({ where }),
+  ]);
+
+  return NextResponse.json({
+    events,
+    pagination: {
+      limit,
+      offset,
+      total,
+      hasMore: offset + events.length < total,
+    },
+  });
+}

--- a/apps/platform/app/o/[slug]/audit/page.tsx
+++ b/apps/platform/app/o/[slug]/audit/page.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  LoadingSpinner,
+  PageHeader,
+} from '@governs-ai/ui';
+import {
+  Activity,
+  AlertCircle,
+  CheckCircle,
+  RefreshCw,
+  XCircle,
+  Zap,
+} from 'lucide-react';
+import PlatformShell from '@/components/platform-shell';
+import { useOrgReady } from '@/lib/use-org-ready';
+
+interface AuditEvent {
+  id: string;
+  orgId: string;
+  direction: 'precheck' | 'postcheck';
+  decision: 'allow' | 'transform' | 'deny';
+  tool?: string | null;
+  correlationId?: string | null;
+  policyId?: string | null;
+  ts: string;
+}
+
+interface AuditResponse {
+  events: AuditEvent[];
+  pagination: { limit: number; offset: number; total: number; hasMore: boolean };
+}
+
+interface Filters {
+  decision: '' | 'allow' | 'transform' | 'deny';
+  tool: string;
+  user: string;
+  from: string;
+  to: string;
+}
+
+const PAGE_SIZE = 50;
+const EMPTY_FILTERS: Filters = { decision: '', tool: '', user: '', from: '', to: '' };
+
+function toQueryString(filters: Filters, offset: number): string {
+  const params = new URLSearchParams();
+  if (filters.decision) params.set('decision', filters.decision);
+  if (filters.tool.trim()) params.set('tool', filters.tool.trim());
+  if (filters.user.trim()) params.set('user', filters.user.trim());
+  if (filters.from) params.set('from', new Date(filters.from).toISOString());
+  if (filters.to) params.set('to', new Date(filters.to).toISOString());
+  params.set('limit', String(PAGE_SIZE));
+  params.set('offset', String(offset));
+  return params.toString();
+}
+
+function decisionBadge(decision: AuditEvent['decision']) {
+  const variant =
+    decision === 'allow' ? 'default' : decision === 'transform' ? 'secondary' : 'destructive';
+  const icon =
+    decision === 'allow' ? (
+      <CheckCircle className="h-4 w-4 text-green-500" />
+    ) : decision === 'transform' ? (
+      <Zap className="h-4 w-4 text-yellow-500" />
+    ) : decision === 'deny' ? (
+      <XCircle className="h-4 w-4 text-red-500" />
+    ) : (
+      <AlertCircle className="h-4 w-4 text-gray-500" />
+    );
+  return (
+    <Badge variant={variant} className="flex items-center gap-1">
+      {icon}
+      {decision}
+    </Badge>
+  );
+}
+
+export default function AuditLogPage() {
+  const params = useParams();
+  const orgSlug = params?.slug as string;
+  const { org, isReady, loading: orgLoading } = useOrgReady(orgSlug);
+
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [appliedFilters, setAppliedFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [offset, setOffset] = useState(0);
+  const [data, setData] = useState<AuditResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEvents = useCallback(
+    async (f: Filters, pageOffset: number) => {
+      setRefreshing(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/v1/audit?${toQueryString(f, pageOffset)}`, {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          setError(body?.error ?? `Request failed (${res.status})`);
+          return;
+        }
+        setData((await res.json()) as AuditResponse);
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!isReady || !org) return;
+    fetchEvents(appliedFilters, offset);
+  }, [isReady, org?.id, appliedFilters, offset, fetchEvents]);
+
+  const applyFilters = () => {
+    setOffset(0);
+    setAppliedFilters(filters);
+  };
+
+  const resetFilters = () => {
+    setFilters(EMPTY_FILTERS);
+    setAppliedFilters(EMPTY_FILTERS);
+    setOffset(0);
+  };
+
+  const pagination = data?.pagination;
+  const pageInfo = useMemo(() => {
+    if (!pagination) return null;
+    const start = pagination.total === 0 ? 0 : pagination.offset + 1;
+    const end = pagination.offset + (data?.events.length ?? 0);
+    return `${start}–${end} of ${pagination.total}`;
+  }, [pagination, data?.events.length]);
+
+  if (!orgLoading && !org) {
+    return (
+      <PlatformShell orgSlug={orgSlug}>
+        <div className="flex items-center justify-center h-64" data-testid="audit-org-not-found-state">
+          <p className="text-muted-foreground">Organization not found.</p>
+        </div>
+      </PlatformShell>
+    );
+  }
+
+  if (loading) {
+    return (
+      <PlatformShell orgSlug={orgSlug}>
+        <div className="flex items-center justify-center h-64" data-testid="audit-loading-state">
+          <LoadingSpinner size="lg" />
+        </div>
+      </PlatformShell>
+    );
+  }
+
+  const events = data?.events ?? [];
+
+  return (
+    <PlatformShell orgSlug={orgSlug}>
+      <div className="space-y-6" data-testid="audit-page">
+        <PageHeader
+          title="Audit Log"
+          subtitle={`Compliance-grade log of AI governance decisions for ${orgSlug}. Filter by decision, tool, user, or time range.`}
+          actions={
+            <Button
+              onClick={() => fetchEvents(appliedFilters, offset)}
+              disabled={refreshing}
+              variant="outline"
+              size="sm"
+            >
+              {refreshing ? <LoadingSpinner size="sm" /> : <RefreshCw className="h-4 w-4" />}
+              {refreshing ? 'Refreshing...' : 'Refresh'}
+            </Button>
+          }
+        />
+
+        <Card>
+          <CardContent className="p-4" data-testid="audit-filter-controls">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">Decision</label>
+                <select
+                  value={filters.decision}
+                  onChange={(e) =>
+                    setFilters((prev) => ({ ...prev, decision: e.target.value as Filters['decision'] }))
+                  }
+                  className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="audit-filter-decision"
+                >
+                  <option value="">All decisions</option>
+                  <option value="allow">Allow</option>
+                  <option value="transform">Transform</option>
+                  <option value="deny">Deny</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">Tool</label>
+                <input
+                  type="text"
+                  value={filters.tool}
+                  onChange={(e) => setFilters((prev) => ({ ...prev, tool: e.target.value }))}
+                  placeholder="e.g. search_web"
+                  className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="audit-filter-tool"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">User</label>
+                <input
+                  type="text"
+                  value={filters.user}
+                  onChange={(e) => setFilters((prev) => ({ ...prev, user: e.target.value }))}
+                  placeholder="correlation id"
+                  className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="audit-filter-user"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">From</label>
+                <input
+                  type="datetime-local"
+                  value={filters.from}
+                  onChange={(e) => setFilters((prev) => ({ ...prev, from: e.target.value }))}
+                  className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="audit-filter-from"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">To</label>
+                <input
+                  type="datetime-local"
+                  value={filters.to}
+                  onChange={(e) => setFilters((prev) => ({ ...prev, to: e.target.value }))}
+                  className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  data-testid="audit-filter-to"
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <Button onClick={applyFilters} size="sm" data-testid="audit-filter-apply">
+                Apply filters
+              </Button>
+              <Button onClick={resetFilters} variant="outline" size="sm" data-testid="audit-filter-reset">
+                Reset
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {error && (
+          <Card data-testid="audit-error">
+            <CardContent className="p-4 text-sm text-destructive">{error}</CardContent>
+          </Card>
+        )}
+
+        {events.length === 0 ? (
+          <Card data-testid="audit-empty-state">
+            <CardContent className="p-8 text-center">
+              <Activity className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium mb-2">No Events</h3>
+              <p className="text-muted-foreground">
+                No audit events match the current filters.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="border rounded-lg overflow-hidden" data-testid="audit-table">
+            <table className="w-full">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Time</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Decision</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Direction</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Tool</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Correlation ID</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">Policy</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {events.map((event) => (
+                  <tr
+                    key={event.id}
+                    className="hover:bg-muted/30"
+                    data-testid={`audit-row-${event.id}`}
+                  >
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      {new Date(event.ts).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3">{decisionBadge(event.decision)}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant="outline">
+                        {event.direction === 'precheck' ? 'Pre-check' : 'Post-check'}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-sm">{event.tool ?? 'N/A'}</td>
+                    <td className="px-4 py-3 text-xs font-mono text-muted-foreground">
+                      {event.correlationId ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-muted-foreground">
+                      {event.policyId ?? '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {pagination && (
+          <div className="flex items-center justify-between" data-testid="audit-pagination">
+            <span className="text-sm text-muted-foreground">{pageInfo}</span>
+            <div className="flex gap-2">
+              <Button
+                onClick={() => setOffset((prev) => Math.max(0, prev - PAGE_SIZE))}
+                disabled={offset === 0 || refreshing}
+                variant="outline"
+                size="sm"
+                data-testid="audit-page-prev"
+              >
+                Previous
+              </Button>
+              <Button
+                onClick={() => setOffset((prev) => prev + PAGE_SIZE)}
+                disabled={!pagination.hasMore || refreshing}
+                variant="outline"
+                size="sm"
+                data-testid="audit-page-next"
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </PlatformShell>
+  );
+}

--- a/apps/platform/components/platform-shell.tsx
+++ b/apps/platform/components/platform-shell.tsx
@@ -5,12 +5,13 @@ import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { cn, Button } from '@governs-ai/ui';
 import { 
-  LayoutDashboard, 
-  Activity, 
-  DollarSign, 
-  Shield, 
-  Key, 
+  LayoutDashboard,
+  Activity,
+  DollarSign,
+  Shield,
+  Key,
   Settings,
+  FileText,
   Search,
   Bell,
   User,
@@ -42,6 +43,7 @@ const getNavigation = (orgSlug: string, userRole?: string): NavigationItem[] => 
   const allItems: NavigationItem[] = [
     { name: 'Dashboard', href: `/o/${orgSlug}/dashboard`, icon: LayoutDashboard },
     { name: 'Tool Calls', href: `/o/${orgSlug}/toolcalls`, icon: Activity },
+    { name: 'Audit Log', href: `/o/${orgSlug}/audit`, icon: FileText },
     { name: 'Spend & Budget', href: `/o/${orgSlug}/spend`, icon: DollarSign },
     { name: 'Manage Tools', href: `/o/${orgSlug}/tools`, icon: Activity, roles: ['OWNER', 'ADMIN', 'DEVELOPER'] },
     { name: 'Policies', href: `/o/${orgSlug}/policies`, icon: Shield },


### PR DESCRIPTION
## Summary
- New `GET /api/v1/audit` endpoint with filters (`decision`, `tool`, `user`, `from`, `to`) and `limit`/`offset` pagination (returns `events`, `pagination.{limit, offset, total, hasMore}`). Auth + orgId scoping come from the session context.
- New dashboard page `/o/[slug]/audit` — filter form, results table, Prev/Next pagination, Apply/Reset.
- Sidebar entry added between Tool Calls and Spend & Budget.

## Data-model note
The `Decision` table has no `userId` column, so the `user` query param is mapped to `correlationId` (the closest per-request identity marker available today). If Atlas adds a proper `userId` field later, switching the filter is a one-line change.

## GovernsAI Tracker issue
GOV-586 — TASKS.md §2.2a

## Reviewers
Tagging @Nexus (code quality) and @Cipher (security/arch) — both approvals required.

## Test plan
- [x] Unit: filter by decision type returns only matching events
- [x] Unit: time range (`from`/`to`) is passed to Prisma as `gte`/`lte`
- [x] Integration-style: filtered API response mirrors Prisma findMany rows, and `findMany` + `count` share the same `where` so totals never diverge
- [x] Pagination: `limit`/`offset`/`hasMore` (incl. final page) + `limit` capped at 500
- [x] 401 when unauthenticated; orgId always sourced from session (query-string `orgId` is ignored)
- [ ] Manual: load `/o/<slug>/audit`, apply each filter in turn, paginate