### PR TITLE
feat(billing): Stripe package + env setup (1.2a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ yarn-error.log*
 *.pem
 
 **/.env*
+!**/.env.example
+!**/env.example
 node-compile-cache/
 packages/db/generated/*
 packages/db/node_modules/*

--- a/apps/platform/.env.example
+++ b/apps/platform/.env.example
@@ -1,0 +1,26 @@
+# GovernsAI Platform — example environment configuration
+#
+# Copy this file to `.env` and fill in real values. Never commit `.env`.
+# The canonical, exhaustive list of environment variables for this app is in
+# docs/environment-variables.md. This example only includes variables added
+# by the Stripe billing integration (TASKS.md §1.2a); merge in other
+# variables from the docs as you need them.
+
+# ---------------------------------------------------------------------------
+# Stripe — billing integration
+# ---------------------------------------------------------------------------
+# Use *test* keys for local development and preview/staging deployments.
+# Live keys are injected at runtime only in production and never committed.
+# Obtain keys from https://dashboard.stripe.com/apikeys
+
+# Server-side secret key — NEVER expose to the browser.
+STRIPE_SECRET_KEY=sk_test_replace_me
+
+# Publishable key — safe for client-side use. The NEXT_PUBLIC_ prefix makes
+# it available in browser bundles (required by @stripe/stripe-js).
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_replace_me
+
+# Webhook signing secret from `stripe listen` (dev) or the Stripe Dashboard
+# webhook endpoint configuration (staging/prod). Used to verify webhook
+# signatures in the billing webhook handler.
+STRIPE_WEBHOOK_SECRET=whsec_replace_me

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -62,6 +62,7 @@
     "sharp": "^0.34.5",
     "speakeasy": "^2.0.0",
     "stream-browserify": "^3.0.0",
+    "stripe": "^22.0.2",
     "tailwind-merge": "^3.3.1",
     "tesseract.js": "^7.0.0",
     "util": "^0.12.5",

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -136,6 +136,32 @@ ENABLE_CONTEXT_MEMORY=true
 ENABLE_CROSS_AGENT_SEARCH=true
 ```
 
+### Stripe Billing
+
+The platform uses Stripe for self-serve billing of paid tiers (Starter / Growth).
+Use **test** keys for local development and preview/staging; live keys are only
+provisioned in production via the deployment platform, never checked into git.
+
+```bash
+# Server-side secret key (sk_test_... / sk_live_...). Never expose to the browser.
+STRIPE_SECRET_KEY="sk_test_..."
+
+# Publishable key (pk_test_... / pk_live_...). Safe for client-side use — the
+# NEXT_PUBLIC_ prefix makes it available to the browser bundle.
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
+
+# Webhook signing secret. Use the value printed by `stripe listen` for local
+# development, and the value from the Dashboard webhook endpoint config for
+# staging/production. Required by the billing webhook handler to verify
+# signatures.
+STRIPE_WEBHOOK_SECRET="whsec_..."
+```
+
+Obtain keys from the [Stripe Dashboard → Developers → API keys](https://dashboard.stripe.com/apikeys).
+All billing development uses test mode; the switch to live keys requires
+explicit product-owner approval and is done via environment configuration, not
+code changes.
+
 ---
 
 ## WebSocket Service (apps/websocket-service)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
+      stripe:
+        specifier: ^22.0.2
+        version: 22.0.2(@types/node@22.16.5)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -4864,6 +4867,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.0.2:
+    resolution: {integrity: sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -10311,6 +10323,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.0.2(@types/node@22.16.5):
+    optionalDependencies:
+      '@types/node': 22.16.5
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- Install `stripe@^22` in `apps/platform`
- Create `apps/platform/.env.example` with placeholders for the three Stripe keys
- Document Stripe env vars in `docs/environment-variables.md`
- Update `.gitignore` so `.env.example` / `env.example` files are trackable (the existing `**/.env*` rule swallowed them)

No runtime code is wired up yet — this is the foundation that unblocks 1.2b (products/prices), 1.2c (pricing page), 1.2d (checkout), 1.2e (webhooks), 1.2f (billing page), 1.2g (usage metering).

### Env variables added
| Var | Scope | Notes |
|---|---|---|
| `STRIPE_SECRET_KEY` | server-only | Test key for dev, live key only in prod via deployment config |
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | client + server | `NEXT_PUBLIC_` prefix so browser bundles can use `@stripe/stripe-js` |
| `STRIPE_WEBHOOK_SECRET` | server-only | From `stripe listen` locally; from Dashboard webhook config in staging/prod |

Minor deviation from the task's literal `STRIPE_PUBLISHABLE_KEY` name: using `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` so it's accessible in client components without a second mirrored variable. Value semantics are identical to Stripe's `STRIPE_PUBLISHABLE_KEY`.

## GovernsAI Tracker issue
GOV-582

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [ ] `pnpm install` succeeds and `stripe` is resolvable from `apps/platform`
- [ ] `cp apps/platform/.env.example apps/platform/.env` works and the file is git-tracked
- [ ] No real secrets in the diff (placeholders only)
- [ ] Docs render correctly in GitHub preview