### PR TITLE
feat(compliance): add async report generation service

### DIFF
--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -168,6 +168,8 @@ Returns `202 Accepted` with:
 }
 ```
 
+`status` values: `pending`, `processing`, `ready`, `failed`.
+
 Poll:
 
 ```http

--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -141,7 +141,16 @@ apps/platform/
 
 ### Compliance Report API Contract
 
-The platform exposes an async compliance summary report workflow for UI consumers:
+The platform exposes an async compliance summary report workflow for UI consumers.
+
+**Access control:** all `/api/v1/reports/*` routes require an authenticated session (or
+API key) **and** an `ADMIN` or `OWNER` org membership. Other roles receive `403 Admin
+access required`.
+
+**Concurrency cap:** each org may have at most
+`COMPLIANCE_REPORT_MAX_ACTIVE_JOBS_PER_ORG` (default `3`) reports in `pending` or
+`processing` state. Additional `POST /generate` calls receive `429` with a `Retry-After`
+header until an existing report finishes.
 
 ```http
 POST /api/v1/reports/generate

--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -139,6 +139,62 @@ apps/platform/
 - **PolicyManagement**: AI usage policy definition and enforcement
 - **AuditLogs**: Complete audit trail of AI interactions
 
+### Compliance Report API Contract
+
+The platform exposes an async compliance summary report workflow for UI consumers:
+
+```http
+POST /api/v1/reports/generate
+Content-Type: application/json
+
+{
+  "startTime": "2026-04-01T00:00:00.000Z",
+  "endTime": "2026-04-24T23:59:59.999Z"
+}
+```
+
+Returns `202 Accepted` with:
+
+```json
+{
+  "report_id": "cuid",
+  "status": "pending",
+  "status_url": "/api/v1/reports/cuid",
+  "download_url": null,
+  "artifacts": {
+    "pdf": null,
+    "json": null
+  }
+}
+```
+
+Poll:
+
+```http
+GET /api/v1/reports/:report_id
+```
+
+Ready response shape:
+
+```json
+{
+  "report_id": "cuid",
+  "status": "ready",
+  "download_url": "/api/v1/reports/cuid?download=1&format=pdf",
+  "artifacts": {
+    "pdf": "/api/v1/reports/cuid?download=1&format=pdf",
+    "json": "/api/v1/reports/cuid?download=1&format=json"
+  }
+}
+```
+
+Artifact downloads:
+
+```http
+GET /api/v1/reports/:report_id?download=1&format=pdf
+GET /api/v1/reports/:report_id?download=1&format=json
+```
+
 ## 🔗 Related Packages
 
 - `@governs-ai/ui` - Shared UI components

--- a/apps/platform/__mocks__/prisma.ts
+++ b/apps/platform/__mocks__/prisma.ts
@@ -16,19 +16,34 @@ export const prisma = {
     findFirst: jest.fn(),
     findMany: jest.fn(),
     create: jest.fn(),
+    count: jest.fn(),
+    updateMany: jest.fn(),
+    deleteMany: jest.fn(),
   },
   user: {
     findUnique: jest.fn(),
     create: jest.fn(),
   },
+  org: {
+    findUnique: jest.fn(),
+  },
+  verificationToken: {
+    count: jest.fn(),
+  },
   budgetLimit: {
     findFirst: jest.fn(),
+    findMany: jest.fn(),
+  },
+  budgetAlert: {
+    findMany: jest.fn(),
   },
   usageRecord: {
     aggregate: jest.fn(),
+    findMany: jest.fn(),
   },
   purchaseRecord: {
     aggregate: jest.fn(),
+    findMany: jest.fn(),
   },
   decision: {
     create: jest.fn(),
@@ -49,7 +64,17 @@ export const prisma = {
   policy: {
     create: jest.fn(),
   },
+  auditLog: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
   contextMemory: {
     findFirst: jest.fn(),
+    findMany: jest.fn(),
+  },
+  complianceReport: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
   },
 };

--- a/apps/platform/__mocks__/prisma.ts
+++ b/apps/platform/__mocks__/prisma.ts
@@ -3,7 +3,7 @@
  * with a jest.fn() so tests can configure return values without a real DB.
  */
 
-export const prisma = {
+const prismaMock: any = {
   aPIKey: {
     findMany: jest.fn(),
     findFirst: jest.fn(),
@@ -75,6 +75,17 @@ export const prisma = {
   complianceReport: {
     create: jest.fn(),
     findUnique: jest.fn(),
+    findFirst: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
+    count: jest.fn(),
   },
+  $transaction: jest.fn(async (arg: any) => {
+    if (typeof arg === 'function') {
+      return arg(prismaMock);
+    }
+    return Promise.all(arg);
+  }),
 };
+
+export const prisma = prismaMock;

--- a/apps/platform/__tests__/api/reports.test.ts
+++ b/apps/platform/__tests__/api/reports.test.ts
@@ -1,0 +1,227 @@
+import { NextRequest } from 'next/server';
+import jwt from 'jsonwebtoken';
+import { prisma } from '@governs-ai/db';
+
+jest.mock('@/lib/services/compliance-report-service', () => ({
+  buildComplianceReportStatus: jest.fn(),
+  createComplianceReportJob: jest.fn(),
+  ensureComplianceReportJobReady: jest.fn(),
+  findComplianceReportJob: jest.fn(),
+  getComplianceReportDownload: jest.fn(),
+  queueComplianceReportJob: jest.fn(),
+}));
+
+import { POST } from '@/app/api/v1/reports/generate/route';
+import { GET } from '@/app/api/v1/reports/[id]/route';
+import {
+  buildComplianceReportStatus,
+  createComplianceReportJob,
+  ensureComplianceReportJobReady,
+  findComplianceReportJob,
+  getComplianceReportDownload,
+  queueComplianceReportJob,
+} from '@/lib/services/compliance-report-service';
+
+const mockPrisma = prisma as any;
+const mockBuildStatus = buildComplianceReportStatus as jest.Mock;
+const mockCreateJob = createComplianceReportJob as jest.Mock;
+const mockEnsureReady = ensureComplianceReportJobReady as jest.Mock;
+const mockFindJob = findComplianceReportJob as jest.Mock;
+const mockGetDownload = getComplianceReportDownload as jest.Mock;
+const mockQueueJob = queueComplianceReportJob as jest.Mock;
+
+function makeToken() {
+  return jwt.sign(
+    {
+      sub: 'user-1',
+      orgId: 'org-1',
+      roles: ['OWNER'],
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+    process.env.JWT_SECRET!
+  );
+}
+
+describe('reports API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a pending report job and returns the async contract', async () => {
+    mockCreateJob.mockResolvedValue({
+      id: 'rpt_pending',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'pending',
+      startTime: new Date('2026-04-01T00:00:00.000Z'),
+      endTime: new Date('2026-04-24T00:00:00.000Z'),
+      generatedAt: null,
+      completedAt: null,
+      errorMessage: null,
+      reportJson: null,
+      pdfData: null,
+      createdAt: new Date('2026-04-24T15:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T15:00:00.000Z'),
+    });
+    mockBuildStatus.mockReturnValue({
+      report_id: 'rpt_pending',
+      status: 'pending',
+      report_type: 'compliance_summary',
+      source: 'on_demand',
+      period: {
+        start_time: '2026-04-01T00:00:00.000Z',
+        end_time: '2026-04-24T00:00:00.000Z',
+      },
+      generated_at: null,
+      created_at: '2026-04-24T15:00:00.000Z',
+      updated_at: '2026-04-24T15:00:00.000Z',
+      error: null,
+      download_url: null,
+      artifacts: {
+        pdf: null,
+        json: null,
+      },
+    });
+
+    const req = new NextRequest('http://localhost/api/v1/reports/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        startTime: '2026-04-01T00:00:00.000Z',
+        endTime: '2026-04-24T00:00:00.000Z',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${makeToken()}`,
+      },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(202);
+
+    const body = await res.json();
+    expect(body).toMatchObject({
+      report_id: 'rpt_pending',
+      status: 'pending',
+      status_url: '/api/v1/reports/rpt_pending',
+      download_url: null,
+    });
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'compliance.report.generate.requested',
+          orgId: 'org-1',
+          userId: 'user-1',
+        }),
+      })
+    );
+    expect(mockQueueJob).toHaveBeenCalledWith('rpt_pending');
+  });
+
+  it('returns report status payloads with artifact URLs', async () => {
+    mockFindJob.mockResolvedValue({
+      id: 'rpt_ready',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'ready',
+      startTime: new Date('2026-04-01T00:00:00.000Z'),
+      endTime: new Date('2026-04-24T00:00:00.000Z'),
+      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
+      completedAt: new Date('2026-04-24T15:00:01.000Z'),
+      errorMessage: null,
+      reportJson: { ok: true },
+      pdfData: Buffer.from('%PDF-1.4'),
+      createdAt: new Date('2026-04-24T15:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+    });
+    mockBuildStatus.mockReturnValue({
+      report_id: 'rpt_ready',
+      status: 'ready',
+      report_type: 'compliance_summary',
+      source: 'on_demand',
+      period: {
+        start_time: '2026-04-01T00:00:00.000Z',
+        end_time: '2026-04-24T00:00:00.000Z',
+      },
+      generated_at: '2026-04-24T15:00:00.000Z',
+      created_at: '2026-04-24T15:00:00.000Z',
+      updated_at: '2026-04-24T15:00:01.000Z',
+      error: null,
+      download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+      artifacts: {
+        pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+        json: '/api/v1/reports/rpt_ready?download=1&format=json',
+      },
+    });
+
+    const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${makeToken()}`,
+      },
+    });
+
+    const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toMatchObject({
+      report_id: 'rpt_ready',
+      status: 'ready',
+      download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+      artifacts: {
+        json: '/api/v1/reports/rpt_ready?download=1&format=json',
+      },
+    });
+  });
+
+  it('downloads the generated JSON artifact once the job is ready', async () => {
+    mockEnsureReady.mockResolvedValue({
+      id: 'rpt_ready',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'ready',
+      startTime: new Date('2026-04-01T00:00:00.000Z'),
+      endTime: new Date('2026-04-24T00:00:00.000Z'),
+      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
+      completedAt: new Date('2026-04-24T15:00:01.000Z'),
+      errorMessage: null,
+      reportJson: { ok: true },
+      pdfData: Buffer.from('%PDF-1.4'),
+      createdAt: new Date('2026-04-24T15:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+    });
+    mockGetDownload.mockReturnValue({
+      body: JSON.stringify({ ok: true }),
+      contentType: 'application/json; charset=utf-8',
+      filename: 'report.json',
+    });
+
+    const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready?download=1&format=json', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${makeToken()}`,
+      },
+    });
+
+    const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+    expect(await res.text()).toContain('"ok":true');
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'compliance.report.download',
+          orgId: 'org-1',
+          userId: 'user-1',
+        }),
+      })
+    );
+  });
+});

--- a/apps/platform/__tests__/api/reports.test.ts
+++ b/apps/platform/__tests__/api/reports.test.ts
@@ -2,40 +2,53 @@ import { NextRequest } from 'next/server';
 import jwt from 'jsonwebtoken';
 import { prisma } from '@governs-ai/db';
 
+const afterCallbacks: Array<() => Promise<void> | void> = [];
+
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server');
+  return {
+    ...actual,
+    after: jest.fn((cb: () => Promise<void> | void) => {
+      afterCallbacks.push(cb);
+    }),
+  };
+});
+
 jest.mock('@/lib/services/compliance-report-service', () => ({
   buildComplianceReportStatus: jest.fn(),
+  countActiveComplianceReportJobs: jest.fn(),
   createComplianceReportJob: jest.fn(),
   ensureComplianceReportJobReady: jest.fn(),
   findComplianceReportJob: jest.fn(),
   getComplianceReportDownload: jest.fn(),
-  queueComplianceReportJob: jest.fn(),
+  processComplianceReportJob: jest.fn(),
 }));
 
 import { POST } from '@/app/api/v1/reports/generate/route';
 import { GET } from '@/app/api/v1/reports/[id]/route';
 import {
   buildComplianceReportStatus,
+  countActiveComplianceReportJobs,
   createComplianceReportJob,
   ensureComplianceReportJobReady,
-  findComplianceReportJob,
   getComplianceReportDownload,
-  queueComplianceReportJob,
+  processComplianceReportJob,
 } from '@/lib/services/compliance-report-service';
 
 const mockPrisma = prisma as any;
 const mockBuildStatus = buildComplianceReportStatus as jest.Mock;
+const mockCountActive = countActiveComplianceReportJobs as jest.Mock;
 const mockCreateJob = createComplianceReportJob as jest.Mock;
 const mockEnsureReady = ensureComplianceReportJobReady as jest.Mock;
-const mockFindJob = findComplianceReportJob as jest.Mock;
 const mockGetDownload = getComplianceReportDownload as jest.Mock;
-const mockQueueJob = queueComplianceReportJob as jest.Mock;
+const mockProcessJob = processComplianceReportJob as jest.Mock;
 
-function makeToken() {
+function makeToken(role: 'OWNER' | 'ADMIN' | 'VIEWER' = 'OWNER') {
   return jwt.sign(
     {
       sub: 'user-1',
       orgId: 'org-1',
-      roles: ['OWNER'],
+      roles: [role],
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + 60 * 60,
     },
@@ -43,185 +56,264 @@ function makeToken() {
   );
 }
 
+function setAdminMembership() {
+  mockPrisma.orgMembership.findFirst.mockResolvedValue({ role: 'OWNER' });
+}
+
+function setNonAdminMembership() {
+  mockPrisma.orgMembership.findFirst.mockResolvedValue(null);
+}
+
+const pendingReport = {
+  id: 'rpt_pending',
+  orgId: 'org-1',
+  requestedById: 'user-1',
+  reportType: 'compliance_summary',
+  source: 'on_demand',
+  status: 'pending',
+  startTime: new Date('2026-04-01T00:00:00.000Z'),
+  endTime: new Date('2026-04-24T00:00:00.000Z'),
+  generatedAt: null,
+  completedAt: null,
+  errorMessage: null,
+  reportJson: null,
+  pdfData: null,
+  createdAt: new Date('2026-04-24T15:00:00.000Z'),
+  updatedAt: new Date('2026-04-24T15:00:00.000Z'),
+};
+
+const readyReport = {
+  ...pendingReport,
+  id: 'rpt_ready',
+  status: 'ready',
+  generatedAt: new Date('2026-04-24T15:00:00.000Z'),
+  completedAt: new Date('2026-04-24T15:00:01.000Z'),
+  reportJson: { ok: true },
+  pdfData: Buffer.from('%PDF-1.4'),
+  updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+};
+
 describe('reports API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    afterCallbacks.length = 0;
+    mockPrisma.$transaction.mockImplementation(async (arg: any) => {
+      if (typeof arg === 'function') {
+        return arg(mockPrisma);
+      }
+      return Promise.all(arg);
+    });
   });
 
-  it('creates a pending report job and returns the async contract', async () => {
-    mockCreateJob.mockResolvedValue({
-      id: 'rpt_pending',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'pending',
-      startTime: new Date('2026-04-01T00:00:00.000Z'),
-      endTime: new Date('2026-04-24T00:00:00.000Z'),
-      generatedAt: null,
-      completedAt: null,
-      errorMessage: null,
-      reportJson: null,
-      pdfData: null,
-      createdAt: new Date('2026-04-24T15:00:00.000Z'),
-      updatedAt: new Date('2026-04-24T15:00:00.000Z'),
-    });
-    mockBuildStatus.mockReturnValue({
-      report_id: 'rpt_pending',
-      status: 'pending',
-      report_type: 'compliance_summary',
-      source: 'on_demand',
-      period: {
-        start_time: '2026-04-01T00:00:00.000Z',
-        end_time: '2026-04-24T00:00:00.000Z',
-      },
-      generated_at: null,
-      created_at: '2026-04-24T15:00:00.000Z',
-      updated_at: '2026-04-24T15:00:00.000Z',
-      error: null,
-      download_url: null,
-      artifacts: {
-        pdf: null,
-        json: null,
-      },
-    });
+  describe('POST /api/v1/reports/generate', () => {
+    it('creates a pending report job, audits in a transaction, schedules after()', async () => {
+      setAdminMembership();
+      mockCountActive.mockResolvedValue(0);
+      mockCreateJob.mockResolvedValue(pendingReport);
+      mockBuildStatus.mockReturnValue({
+        report_id: 'rpt_pending',
+        status: 'pending',
+        report_type: 'compliance_summary',
+        source: 'on_demand',
+        period: {
+          start_time: '2026-04-01T00:00:00.000Z',
+          end_time: '2026-04-24T00:00:00.000Z',
+        },
+        generated_at: null,
+        created_at: '2026-04-24T15:00:00.000Z',
+        updated_at: '2026-04-24T15:00:00.000Z',
+        error: null,
+        download_url: null,
+        artifacts: { pdf: null, json: null },
+      });
 
-    const req = new NextRequest('http://localhost/api/v1/reports/generate', {
-      method: 'POST',
-      body: JSON.stringify({
-        startTime: '2026-04-01T00:00:00.000Z',
-        endTime: '2026-04-24T00:00:00.000Z',
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${makeToken()}`,
-      },
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(202);
-
-    const body = await res.json();
-    expect(body).toMatchObject({
-      report_id: 'rpt_pending',
-      status: 'pending',
-      status_url: '/api/v1/reports/rpt_pending',
-      download_url: null,
-    });
-    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          action: 'compliance.report.generate.requested',
-          orgId: 'org-1',
-          userId: 'user-1',
+      const req = new NextRequest('http://localhost/api/v1/reports/generate', {
+        method: 'POST',
+        body: JSON.stringify({
+          startTime: '2026-04-01T00:00:00.000Z',
+          endTime: '2026-04-24T00:00:00.000Z',
         }),
-      })
-    );
-    expect(mockQueueJob).toHaveBeenCalledWith('rpt_pending');
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${makeToken('OWNER')}`,
+        },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(202);
+
+      const body = await res.json();
+      expect(body).toMatchObject({
+        report_id: 'rpt_pending',
+        status: 'pending',
+        status_url: '/api/v1/reports/rpt_pending',
+        download_url: null,
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'compliance.report.generate.requested',
+            orgId: 'org-1',
+            userId: 'user-1',
+          }),
+        })
+      );
+      // after() registered exactly one callback for async processing
+      expect(afterCallbacks).toHaveLength(1);
+      mockProcessJob.mockResolvedValue(readyReport);
+      await afterCallbacks[0]();
+      expect(mockProcessJob).toHaveBeenCalledWith('rpt_pending');
+    });
+
+    it('returns 401 when no auth is provided', async () => {
+      const req = new NextRequest('http://localhost/api/v1/reports/generate', {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+      expect(mockCreateJob).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the caller is not ADMIN or OWNER', async () => {
+      setNonAdminMembership();
+
+      const req = new NextRequest('http://localhost/api/v1/reports/generate', {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${makeToken('VIEWER')}`,
+        },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(403);
+      expect(mockCreateJob).not.toHaveBeenCalled();
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rate-limits when too many active jobs are already queued for the org', async () => {
+      setAdminMembership();
+      mockCountActive.mockResolvedValue(10);
+
+      const req = new NextRequest('http://localhost/api/v1/reports/generate', {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${makeToken('OWNER')}`,
+        },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBe('30');
+      expect(mockCreateJob).not.toHaveBeenCalled();
+    });
   });
 
-  it('returns report status payloads with artifact URLs', async () => {
-    mockFindJob.mockResolvedValue({
-      id: 'rpt_ready',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'ready',
-      startTime: new Date('2026-04-01T00:00:00.000Z'),
-      endTime: new Date('2026-04-24T00:00:00.000Z'),
-      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
-      completedAt: new Date('2026-04-24T15:00:01.000Z'),
-      errorMessage: null,
-      reportJson: { ok: true },
-      pdfData: Buffer.from('%PDF-1.4'),
-      createdAt: new Date('2026-04-24T15:00:00.000Z'),
-      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
-    });
-    mockBuildStatus.mockReturnValue({
-      report_id: 'rpt_ready',
-      status: 'ready',
-      report_type: 'compliance_summary',
-      source: 'on_demand',
-      period: {
-        start_time: '2026-04-01T00:00:00.000Z',
-        end_time: '2026-04-24T00:00:00.000Z',
-      },
-      generated_at: '2026-04-24T15:00:00.000Z',
-      created_at: '2026-04-24T15:00:00.000Z',
-      updated_at: '2026-04-24T15:00:01.000Z',
-      error: null,
-      download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
-      artifacts: {
-        pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
-        json: '/api/v1/reports/rpt_ready?download=1&format=json',
-      },
+  describe('GET /api/v1/reports/[id]', () => {
+    it('returns 401 when unauthenticated', async () => {
+      const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready', {
+        method: 'GET',
+      });
+
+      const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+      expect(res.status).toBe(401);
     });
 
-    const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${makeToken()}`,
-      },
+    it('returns 403 when the caller is not ADMIN or OWNER', async () => {
+      setNonAdminMembership();
+
+      const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${makeToken('VIEWER')}` },
+      });
+
+      const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+      expect(res.status).toBe(403);
+      expect(mockEnsureReady).not.toHaveBeenCalled();
     });
 
-    const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
-    expect(res.status).toBe(200);
+    it('returns report status payloads with artifact URLs', async () => {
+      setAdminMembership();
+      mockEnsureReady.mockResolvedValue(readyReport);
+      mockBuildStatus.mockReturnValue({
+        report_id: 'rpt_ready',
+        status: 'ready',
+        report_type: 'compliance_summary',
+        source: 'on_demand',
+        period: {
+          start_time: '2026-04-01T00:00:00.000Z',
+          end_time: '2026-04-24T00:00:00.000Z',
+        },
+        generated_at: '2026-04-24T15:00:00.000Z',
+        created_at: '2026-04-24T15:00:00.000Z',
+        updated_at: '2026-04-24T15:00:01.000Z',
+        error: null,
+        download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+        artifacts: {
+          pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+          json: '/api/v1/reports/rpt_ready?download=1&format=json',
+        },
+      });
 
-    const body = await res.json();
-    expect(body).toMatchObject({
-      report_id: 'rpt_ready',
-      status: 'ready',
-      download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
-      artifacts: {
-        json: '/api/v1/reports/rpt_ready?download=1&format=json',
-      },
-    });
-  });
+      const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${makeToken('OWNER')}` },
+      });
 
-  it('downloads the generated JSON artifact once the job is ready', async () => {
-    mockEnsureReady.mockResolvedValue({
-      id: 'rpt_ready',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'ready',
-      startTime: new Date('2026-04-01T00:00:00.000Z'),
-      endTime: new Date('2026-04-24T00:00:00.000Z'),
-      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
-      completedAt: new Date('2026-04-24T15:00:01.000Z'),
-      errorMessage: null,
-      reportJson: { ok: true },
-      pdfData: Buffer.from('%PDF-1.4'),
-      createdAt: new Date('2026-04-24T15:00:00.000Z'),
-      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
-    });
-    mockGetDownload.mockReturnValue({
-      body: JSON.stringify({ ok: true }),
-      contentType: 'application/json; charset=utf-8',
-      filename: 'report.json',
+      const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toMatchObject({
+        report_id: 'rpt_ready',
+        status: 'ready',
+        download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+        artifacts: {
+          json: '/api/v1/reports/rpt_ready?download=1&format=json',
+        },
+      });
+      // self-heal path: status GET also calls ensureComplianceReportJobReady
+      expect(mockEnsureReady).toHaveBeenCalledWith('rpt_ready', 'org-1');
     });
 
-    const req = new NextRequest('http://localhost/api/v1/reports/rpt_ready?download=1&format=json', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${makeToken()}`,
-      },
-    });
+    it('downloads the generated JSON artifact once the job is ready', async () => {
+      setAdminMembership();
+      mockEnsureReady.mockResolvedValue(readyReport);
+      mockGetDownload.mockReturnValue({
+        body: JSON.stringify({ ok: true }),
+        contentType: 'application/json; charset=utf-8',
+        filename: 'report.json',
+      });
 
-    const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
-    expect(await res.text()).toContain('"ok":true');
-    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          action: 'compliance.report.download',
-          orgId: 'org-1',
-          userId: 'user-1',
-        }),
-      })
-    );
+      const req = new NextRequest(
+        'http://localhost/api/v1/reports/rpt_ready?download=1&format=json',
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${makeToken('OWNER')}` },
+        }
+      );
+
+      const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+      expect(await res.text()).toContain('"ok":true');
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'compliance.report.download',
+            orgId: 'org-1',
+            userId: 'user-1',
+          }),
+        })
+      );
+    });
   });
 });

--- a/apps/platform/__tests__/lib/compliance-report-service.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-service.test.ts
@@ -3,6 +3,9 @@ import {
   buildComplianceReport,
   buildComplianceReportStatus,
   complianceReportToPdf,
+  countActiveComplianceReportJobs,
+  findComplianceReportJob,
+  processComplianceReportJob,
 } from '@/lib/services/compliance-report-service';
 
 const mockPrisma = prisma as any;
@@ -199,6 +202,123 @@ describe('compliance-report-service', () => {
 
     expect(pdf.byteLength).toBeGreaterThan(200);
     expect(pdf.toString('utf8', 0, 8)).toContain('%PDF-1.4');
+  });
+
+  it('scopes findComplianceReportJob lookups by orgId at the database boundary', async () => {
+    mockPrisma.complianceReport.findFirst.mockResolvedValue({
+      id: 'rpt_x',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'pending',
+      startTime: null,
+      endTime: null,
+      generatedAt: null,
+      completedAt: null,
+      errorMessage: null,
+      reportJson: null,
+      pdfData: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await findComplianceReportJob('rpt_x', 'org-1');
+
+    expect(result?.id).toBe('rpt_x');
+    expect(mockPrisma.complianceReport.findFirst).toHaveBeenCalledWith({
+      where: { id: 'rpt_x', orgId: 'org-1' },
+    });
+  });
+
+  it('counts only active (pending|processing) jobs per org for rate limiting', async () => {
+    mockPrisma.complianceReport.count.mockResolvedValue(2);
+
+    const total = await countActiveComplianceReportJobs('org-1');
+
+    expect(total).toBe(2);
+    expect(mockPrisma.complianceReport.count).toHaveBeenCalledWith({
+      where: {
+        orgId: 'org-1',
+        status: { in: ['pending', 'processing'] },
+      },
+    });
+  });
+
+  it('processComplianceReportJob short-circuits when the atomic claim is lost (already processing)', async () => {
+    mockPrisma.complianceReport.findUnique.mockResolvedValue({
+      id: 'rpt_locked',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'processing',
+      startTime: null,
+      endTime: null,
+      generatedAt: null,
+      completedAt: null,
+      errorMessage: null,
+      reportJson: null,
+      pdfData: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await processComplianceReportJob('rpt_locked');
+
+    expect(result.id).toBe('rpt_locked');
+    expect(result.status).toBe('processing');
+    // No build pipeline calls happen when the claim is lost.
+    expect(mockPrisma.complianceReport.update).not.toHaveBeenCalled();
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('processComplianceReportJob proceeds when the atomic claim succeeds', async () => {
+    const jobRow = {
+      id: 'rpt_claimed',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'pending',
+      startTime: null,
+      endTime: null,
+      generatedAt: null,
+      completedAt: null,
+      errorMessage: null,
+      reportJson: null,
+      pdfData: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
+    mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.complianceReport.update.mockResolvedValue({ ...jobRow, status: 'ready' });
+
+    // Minimal stubs for the build pipeline so it doesn't blow up.
+    mockPrisma.decision.findMany.mockResolvedValue([]);
+    mockPrisma.contextMemory.findMany.mockResolvedValue([]);
+    mockPrisma.budgetAlert.findMany.mockResolvedValue([]);
+    mockPrisma.budgetLimit.findMany.mockResolvedValue([]);
+    mockPrisma.usageRecord.findMany.mockResolvedValue([]);
+    mockPrisma.purchaseRecord.findMany.mockResolvedValue([]);
+    mockPrisma.orgMembership.findMany.mockResolvedValue([]);
+    mockPrisma.verificationToken.count.mockResolvedValue(0);
+
+    await processComplianceReportJob('rpt_claimed');
+
+    expect(mockPrisma.complianceReport.updateMany).toHaveBeenCalledWith({
+      where: { id: 'rpt_claimed', status: { in: ['pending', 'failed'] } },
+      data: { status: 'processing', errorMessage: null },
+    });
+    expect(mockPrisma.complianceReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'rpt_claimed' },
+        data: expect.objectContaining({ status: 'ready' }),
+      })
+    );
   });
 
   it('publishes status payloads with artifact URLs once the report is ready', () => {

--- a/apps/platform/__tests__/lib/compliance-report-service.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-service.test.ts
@@ -1,0 +1,231 @@
+import { prisma } from '@governs-ai/db';
+import {
+  buildComplianceReport,
+  buildComplianceReportStatus,
+  complianceReportToPdf,
+} from '@/lib/services/compliance-report-service';
+
+const mockPrisma = prisma as any;
+
+describe('compliance-report-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds the compliance report schema with the required governance summary fields', async () => {
+    mockPrisma.decision.findMany.mockResolvedValue([
+      {
+        decision: 'allow',
+        tool: 'model.chat',
+        policyId: 'policy-a',
+        reasons: ['safe'],
+        latencyMs: 12,
+        ts: new Date('2026-04-21T12:00:00.000Z'),
+      },
+      {
+        decision: 'deny',
+        tool: 'browser.search',
+        policyId: 'policy-b',
+        reasons: ['PII:email_address'],
+        latencyMs: 24,
+        ts: new Date('2026-04-21T12:05:00.000Z'),
+      },
+      {
+        decision: 'transform',
+        tool: 'model.chat',
+        policyId: null,
+        reasons: [{ code: 'PII:phone_number' }],
+        latencyMs: 30,
+        ts: new Date('2026-04-21T12:10:00.000Z'),
+      },
+    ]);
+    mockPrisma.contextMemory.findMany.mockResolvedValue([
+      {
+        piiDetected: true,
+        piiRedacted: false,
+        precheckDecision: 'allow',
+        createdAt: new Date('2026-04-21T11:55:00.000Z'),
+      },
+      {
+        piiDetected: true,
+        piiRedacted: true,
+        precheckDecision: 'redact',
+        createdAt: new Date('2026-04-21T11:56:00.000Z'),
+      },
+    ]);
+    mockPrisma.budgetAlert.findMany.mockResolvedValue([
+      {
+        type: 'threshold_reached',
+        message: 'Organization budget at 90%',
+        createdAt: new Date('2026-04-21T12:15:00.000Z'),
+      },
+    ]);
+    mockPrisma.budgetLimit.findMany.mockResolvedValue([
+      {
+        type: 'organization',
+        userId: null,
+        monthlyLimit: 50,
+      },
+    ]);
+    mockPrisma.usageRecord.findMany.mockResolvedValue([
+      { tool: 'model.chat', cost: 35 },
+      { tool: 'browser.search', cost: 20 },
+    ]);
+    mockPrisma.purchaseRecord.findMany.mockResolvedValue([{ amount: 10 }]);
+    mockPrisma.orgMembership.findMany
+      .mockResolvedValueOnce([
+        {
+          userId: 'user-2',
+          role: 'ADMIN',
+          createdAt: new Date('2026-04-21T10:00:00.000Z'),
+          user: { email: 'new-admin@example.com' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: 'user-1',
+          role: 'OWNER',
+          createdAt: new Date('2026-04-01T00:00:00.000Z'),
+          user: { email: 'owner@example.com' },
+        },
+        {
+          userId: 'user-2',
+          role: 'ADMIN',
+          createdAt: new Date('2026-04-21T10:00:00.000Z'),
+          user: { email: 'new-admin@example.com' },
+        },
+      ]);
+    mockPrisma.verificationToken.count.mockResolvedValue(2);
+
+    const report = await buildComplianceReport({
+      reportId: 'rpt_123',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      startTime: new Date('2026-04-01T00:00:00.000Z'),
+      endTime: new Date('2026-04-24T00:00:00.000Z'),
+      source: 'on_demand',
+    });
+
+    expect(report.reportType).toBe('compliance_summary');
+    expect(report.reportId).toBe('rpt_123');
+    expect(report.summary).toEqual({
+      policyDecisions: 3,
+      piiEvents: 4,
+      budgetOverruns: 1,
+      userAccessChanges: 3,
+      toolInvocations: 3,
+    });
+    expect(report.policyDecisions.byDecision).toEqual({
+      allow: 1,
+      deny: 1,
+      transform: 1,
+    });
+    expect(report.piiEvents.uniqueSignals).toEqual(['email_address', 'phone_number']);
+    expect(report.budget.overrunCount).toBe(1);
+    expect(report.userAccess.roleDistribution).toEqual({
+      OWNER: 1,
+      ADMIN: 1,
+    });
+    expect(report.toolInvocations.topTools).toEqual([
+      { tool: 'model.chat', count: 2, totalCost: 35 },
+      { tool: 'browser.search', count: 1, totalCost: 20 },
+    ]);
+  });
+
+  it('renders a non-empty PDF artifact for a ready report', async () => {
+    const pdf = complianceReportToPdf({
+      version: 1,
+      reportType: 'compliance_summary',
+      reportId: 'rpt_pdf',
+      generatedAt: '2026-04-24T15:00:00.000Z',
+      orgId: 'org-1',
+      period: {
+        startTime: '2026-04-01T00:00:00.000Z',
+        endTime: '2026-04-24T00:00:00.000Z',
+      },
+      requestedBy: {
+        userId: 'user-1',
+        source: 'on_demand',
+      },
+      summary: {
+        policyDecisions: 10,
+        piiEvents: 3,
+        budgetOverruns: 1,
+        userAccessChanges: 2,
+        toolInvocations: 8,
+      },
+      policyDecisions: {
+        total: 10,
+        byDecision: { allow: 8, deny: 2 },
+        averageLatencyMs: 18,
+        topTools: [{ tool: 'model.chat', count: 6 }],
+        topPolicies: [{ policyId: 'policy-a', count: 5 }],
+      },
+      piiEvents: {
+        total: 3,
+        contextsDetected: 2,
+        contextsRedacted: 1,
+        decisionsFlagged: 1,
+        uniqueSignals: ['email_address'],
+        recentEvents: [],
+      },
+      budget: {
+        overrunCount: 1,
+        alertsTriggered: 1,
+        totalUsageCost: 42.25,
+        totalPurchaseAmount: 5,
+        affectedBudgets: [
+          {
+            scope: 'organization',
+            userId: null,
+            monthlyLimit: 40,
+            spendInPeriod: 47.25,
+          },
+        ],
+      },
+      userAccess: {
+        totalMembers: 4,
+        newMembers: 1,
+        invitesSent: 1,
+        roleDistribution: { OWNER: 1, ADMIN: 1, VIEWER: 2 },
+        recentMembers: [],
+      },
+      toolInvocations: {
+        total: 8,
+        uniqueTools: 2,
+        topTools: [{ tool: 'model.chat', count: 6, totalCost: 42.25 }],
+      },
+    });
+
+    expect(pdf.byteLength).toBeGreaterThan(200);
+    expect(pdf.toString('utf8', 0, 8)).toContain('%PDF-1.4');
+  });
+
+  it('publishes status payloads with artifact URLs once the report is ready', () => {
+    const payload = buildComplianceReportStatus({
+      id: 'rpt_ready',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'ready',
+      startTime: new Date('2026-04-01T00:00:00.000Z'),
+      endTime: new Date('2026-04-24T00:00:00.000Z'),
+      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
+      completedAt: new Date('2026-04-24T15:00:01.000Z'),
+      errorMessage: null,
+      reportJson: null,
+      pdfData: Buffer.from('%PDF-1.4'),
+      createdAt: new Date('2026-04-24T14:59:00.000Z'),
+      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+    });
+
+    expect(payload.report_id).toBe('rpt_ready');
+    expect(payload.status).toBe('ready');
+    expect(payload.download_url).toBe('/api/v1/reports/rpt_ready?download=1&format=pdf');
+    expect(payload.artifacts).toEqual({
+      pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
+      json: '/api/v1/reports/rpt_ready?download=1&format=json',
+    });
+  });
+});

--- a/apps/platform/app/api/v1/reports/[id]/route.ts
+++ b/apps/platform/app/api/v1/reports/[id]/route.ts
@@ -1,55 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@governs-ai/db';
-import { verifySessionToken } from '@/lib/auth-server';
+import { resolveReportAuth, requireReportAdmin } from '@/lib/auth/report-access';
 import {
   buildComplianceReportStatus,
   ensureComplianceReportJobReady,
-  findComplianceReportJob,
   getComplianceReportDownload,
   type ComplianceReportFormat,
 } from '@/lib/services/compliance-report-service';
 
 export const runtime = 'nodejs';
 export const maxDuration = 180;
-
-interface AuthContext {
-  userId: string;
-  orgId: string;
-}
-
-async function resolveAuth(request: NextRequest): Promise<AuthContext | null> {
-  const authHeader = request.headers.get('authorization');
-  const apiKeyHeader = request.headers.get('x-governs-key');
-  const sessionCookie = request.cookies.get('session')?.value;
-
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.slice('Bearer '.length).trim();
-    const session = verifySessionToken(token);
-    if (session) {
-      return { userId: session.sub, orgId: session.orgId };
-    }
-  }
-
-  if (apiKeyHeader) {
-    const apiKey = await prisma.aPIKey.findFirst({
-      where: { key: apiKeyHeader, isActive: true },
-      select: { userId: true, orgId: true },
-    });
-
-    if (apiKey) {
-      return { userId: apiKey.userId, orgId: apiKey.orgId };
-    }
-  }
-
-  if (sessionCookie) {
-    const session = verifySessionToken(sessionCookie);
-    if (session) {
-      return { userId: session.sub, orgId: session.orgId };
-    }
-  }
-
-  return null;
-}
 
 function parseFormat(value: string | null): ComplianceReportFormat {
   return value === 'json' ? 'json' : 'pdf';
@@ -60,9 +20,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const auth = await resolveAuth(request);
+    const auth = await resolveReportAuth(request);
     if (!auth) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const adminCheck = await requireReportAdmin(auth);
+    if (!adminCheck.allowed) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
     }
 
     const { id } = await params;
@@ -70,9 +35,7 @@ export async function GET(
     const downloadRequested = searchParams.get('download') === '1';
     const format = parseFormat(searchParams.get('format'));
 
-    const report = downloadRequested
-      ? await ensureComplianceReportJobReady(id, auth.orgId)
-      : await findComplianceReportJob(id, auth.orgId);
+    const report = await ensureComplianceReportJobReady(id, auth.orgId);
 
     if (!report) {
       return NextResponse.json({ error: 'Report not found' }, { status: 404 });
@@ -88,7 +51,7 @@ export async function GET(
       return NextResponse.json(
         {
           error: 'Report generation failed',
-          details: report.errorMessage || 'Unknown error',
+          status: report.status,
         },
         { status: 409 }
       );
@@ -129,10 +92,7 @@ export async function GET(
   } catch (error) {
     console.error('Error fetching compliance report:', error);
     return NextResponse.json(
-      {
-        error: 'Failed to fetch compliance report',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: 'Failed to fetch compliance report' },
       { status: 500 }
     );
   }

--- a/apps/platform/app/api/v1/reports/[id]/route.ts
+++ b/apps/platform/app/api/v1/reports/[id]/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@governs-ai/db';
+import { verifySessionToken } from '@/lib/auth-server';
+import {
+  buildComplianceReportStatus,
+  ensureComplianceReportJobReady,
+  findComplianceReportJob,
+  getComplianceReportDownload,
+  type ComplianceReportFormat,
+} from '@/lib/services/compliance-report-service';
+
+export const runtime = 'nodejs';
+export const maxDuration = 180;
+
+interface AuthContext {
+  userId: string;
+  orgId: string;
+}
+
+async function resolveAuth(request: NextRequest): Promise<AuthContext | null> {
+  const authHeader = request.headers.get('authorization');
+  const apiKeyHeader = request.headers.get('x-governs-key');
+  const sessionCookie = request.cookies.get('session')?.value;
+
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length).trim();
+    const session = verifySessionToken(token);
+    if (session) {
+      return { userId: session.sub, orgId: session.orgId };
+    }
+  }
+
+  if (apiKeyHeader) {
+    const apiKey = await prisma.aPIKey.findFirst({
+      where: { key: apiKeyHeader, isActive: true },
+      select: { userId: true, orgId: true },
+    });
+
+    if (apiKey) {
+      return { userId: apiKey.userId, orgId: apiKey.orgId };
+    }
+  }
+
+  if (sessionCookie) {
+    const session = verifySessionToken(sessionCookie);
+    if (session) {
+      return { userId: session.sub, orgId: session.orgId };
+    }
+  }
+
+  return null;
+}
+
+function parseFormat(value: string | null): ComplianceReportFormat {
+  return value === 'json' ? 'json' : 'pdf';
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuth(request);
+    if (!auth) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const downloadRequested = searchParams.get('download') === '1';
+    const format = parseFormat(searchParams.get('format'));
+
+    const report = downloadRequested
+      ? await ensureComplianceReportJobReady(id, auth.orgId)
+      : await findComplianceReportJob(id, auth.orgId);
+
+    if (!report) {
+      return NextResponse.json({ error: 'Report not found' }, { status: 404 });
+    }
+
+    if (!downloadRequested) {
+      return NextResponse.json(buildComplianceReportStatus(report), {
+        headers: { 'Cache-Control': 'no-store' },
+      });
+    }
+
+    if (report.status === 'failed') {
+      return NextResponse.json(
+        {
+          error: 'Report generation failed',
+          details: report.errorMessage || 'Unknown error',
+        },
+        { status: 409 }
+      );
+    }
+
+    if (report.status !== 'ready') {
+      return NextResponse.json(
+        {
+          error: 'Report is still processing',
+          status: report.status,
+        },
+        { status: 409 }
+      );
+    }
+
+    const asset = getComplianceReportDownload(report, format);
+
+    await prisma.auditLog.create({
+      data: {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        action: 'compliance.report.download',
+        resource: 'compliance_report',
+        details: {
+          reportId: report.id,
+          format,
+        },
+      },
+    });
+
+    return new NextResponse(asset.body, {
+      headers: {
+        'Content-Type': asset.contentType,
+        'Content-Disposition': `attachment; filename="${asset.filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching compliance report:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch compliance report',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/app/api/v1/reports/generate/route.ts
+++ b/apps/platform/app/api/v1/reports/generate/route.ts
@@ -1,53 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { after } from 'next/server';
 import { prisma } from '@governs-ai/db';
-import { verifySessionToken } from '@/lib/auth-server';
+import { resolveReportAuth, requireReportAdmin } from '@/lib/auth/report-access';
 import {
   buildComplianceReportStatus,
+  countActiveComplianceReportJobs,
   createComplianceReportJob,
-  queueComplianceReportJob,
+  processComplianceReportJob,
 } from '@/lib/services/compliance-report-service';
 
 export const runtime = 'nodejs';
 export const maxDuration = 180;
 
-interface AuthContext {
-  userId: string;
-  orgId: string;
-}
-
-async function resolveAuth(request: NextRequest): Promise<AuthContext | null> {
-  const authHeader = request.headers.get('authorization');
-  const apiKeyHeader = request.headers.get('x-governs-key');
-  const sessionCookie = request.cookies.get('session')?.value;
-
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.slice('Bearer '.length).trim();
-    const session = verifySessionToken(token);
-    if (session) {
-      return { userId: session.sub, orgId: session.orgId };
-    }
-  }
-
-  if (apiKeyHeader) {
-    const apiKey = await prisma.aPIKey.findFirst({
-      where: { key: apiKeyHeader, isActive: true },
-      select: { userId: true, orgId: true },
-    });
-
-    if (apiKey) {
-      return { userId: apiKey.userId, orgId: apiKey.orgId };
-    }
-  }
-
-  if (sessionCookie) {
-    const session = verifySessionToken(sessionCookie);
-    if (session) {
-      return { userId: session.sub, orgId: session.orgId };
-    }
-  }
-
-  return null;
-}
+const MAX_ACTIVE_JOBS_PER_ORG = Number(
+  process.env.COMPLIANCE_REPORT_MAX_ACTIVE_JOBS_PER_ORG || 3
+);
 
 function parseDate(value: unknown): Date | undefined {
   if (typeof value !== 'string' || value.length === 0) {
@@ -60,9 +27,14 @@ function parseDate(value: unknown): Date | undefined {
 
 export async function POST(request: NextRequest) {
   try {
-    const auth = await resolveAuth(request);
+    const auth = await resolveReportAuth(request);
     if (!auth) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const adminCheck = await requireReportAdmin(auth);
+    if (!adminCheck.allowed) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
     }
 
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
@@ -84,33 +56,63 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const report = await createComplianceReportJob({
-      orgId: auth.orgId,
-      requestedById: auth.userId,
-      startTime,
-      endTime,
-      source: 'on_demand',
-    });
+    const activeCount = await countActiveComplianceReportJobs(auth.orgId);
+    if (activeCount >= MAX_ACTIVE_JOBS_PER_ORG) {
+      return NextResponse.json(
+        {
+          error: 'Too many compliance reports in progress. Wait for an existing report to finish.',
+          retryable: true,
+        },
+        {
+          status: 429,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Retry-After': '30',
+          },
+        }
+      );
+    }
 
-    await prisma.auditLog.create({
-      data: {
-        userId: auth.userId,
-        orgId: auth.orgId,
-        action: 'compliance.report.generate.requested',
-        resource: 'compliance_report',
-        details: {
-          reportId: report.id,
-          reportType: report.reportType,
-          source: report.source,
-          period: {
-            startTime: startTime?.toISOString() || null,
-            endTime: endTime?.toISOString() || null,
+    const report = await prisma.$transaction(async (tx) => {
+      const created = await createComplianceReportJob(
+        {
+          orgId: auth.orgId,
+          requestedById: auth.userId,
+          startTime,
+          endTime,
+          source: 'on_demand',
+        },
+        tx
+      );
+
+      await tx.auditLog.create({
+        data: {
+          userId: auth.userId,
+          orgId: auth.orgId,
+          action: 'compliance.report.generate.requested',
+          resource: 'compliance_report',
+          details: {
+            reportId: created.id,
+            reportType: created.reportType,
+            source: created.source,
+            period: {
+              startTime: startTime?.toISOString() || null,
+              endTime: endTime?.toISOString() || null,
+            },
           },
         },
-      },
+      });
+
+      return created;
     });
 
-    await queueComplianceReportJob(report.id);
+    after(async () => {
+      try {
+        await processComplianceReportJob(report.id);
+      } catch (error) {
+        console.error('Async compliance report generation failed:', error);
+      }
+    });
 
     return NextResponse.json(
       {
@@ -122,10 +124,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Error creating compliance report job:', error);
     return NextResponse.json(
-      {
-        error: 'Failed to generate compliance report',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: 'Failed to generate compliance report' },
       { status: 500 }
     );
   }

--- a/apps/platform/app/api/v1/reports/generate/route.ts
+++ b/apps/platform/app/api/v1/reports/generate/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@governs-ai/db';
+import { verifySessionToken } from '@/lib/auth-server';
+import {
+  buildComplianceReportStatus,
+  createComplianceReportJob,
+  queueComplianceReportJob,
+} from '@/lib/services/compliance-report-service';
+
+export const runtime = 'nodejs';
+export const maxDuration = 180;
+
+interface AuthContext {
+  userId: string;
+  orgId: string;
+}
+
+async function resolveAuth(request: NextRequest): Promise<AuthContext | null> {
+  const authHeader = request.headers.get('authorization');
+  const apiKeyHeader = request.headers.get('x-governs-key');
+  const sessionCookie = request.cookies.get('session')?.value;
+
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length).trim();
+    const session = verifySessionToken(token);
+    if (session) {
+      return { userId: session.sub, orgId: session.orgId };
+    }
+  }
+
+  if (apiKeyHeader) {
+    const apiKey = await prisma.aPIKey.findFirst({
+      where: { key: apiKeyHeader, isActive: true },
+      select: { userId: true, orgId: true },
+    });
+
+    if (apiKey) {
+      return { userId: apiKey.userId, orgId: apiKey.orgId };
+    }
+  }
+
+  if (sessionCookie) {
+    const session = verifySessionToken(sessionCookie);
+    if (session) {
+      return { userId: session.sub, orgId: session.orgId };
+    }
+  }
+
+  return null;
+}
+
+function parseDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await resolveAuth(request);
+    if (!auth) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const startTime = parseDate(body.startTime);
+    const endTime = parseDate(body.endTime);
+
+    if (body.startTime && !startTime) {
+      return NextResponse.json({ error: 'Invalid startTime' }, { status: 400 });
+    }
+
+    if (body.endTime && !endTime) {
+      return NextResponse.json({ error: 'Invalid endTime' }, { status: 400 });
+    }
+
+    if (startTime && endTime && startTime > endTime) {
+      return NextResponse.json(
+        { error: 'startTime must be earlier than endTime' },
+        { status: 400 }
+      );
+    }
+
+    const report = await createComplianceReportJob({
+      orgId: auth.orgId,
+      requestedById: auth.userId,
+      startTime,
+      endTime,
+      source: 'on_demand',
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        action: 'compliance.report.generate.requested',
+        resource: 'compliance_report',
+        details: {
+          reportId: report.id,
+          reportType: report.reportType,
+          source: report.source,
+          period: {
+            startTime: startTime?.toISOString() || null,
+            endTime: endTime?.toISOString() || null,
+          },
+        },
+      },
+    });
+
+    await queueComplianceReportJob(report.id);
+
+    return NextResponse.json(
+      {
+        ...buildComplianceReportStatus(report),
+        status_url: `/api/v1/reports/${report.id}`,
+      },
+      { status: 202, headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Error creating compliance report job:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to generate compliance report',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/platform/jest.setup.ts
+++ b/apps/platform/jest.setup.ts
@@ -2,5 +2,6 @@
 // The webhook route throws at module load time if WEBHOOK_SECRET is absent.
 process.env.WEBHOOK_SECRET = 'test-webhook-secret-for-ci';
 process.env.JWT_SECRET = 'test-jwt-secret-for-ci';
+process.env.PASSWORD_PEPPER = 'test-password-pepper-for-ci';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test_ci';
 // NODE_ENV is read-only in TypeScript strict mode; it is already 'test' when jest runs

--- a/apps/platform/lib/auth/report-access.ts
+++ b/apps/platform/lib/auth/report-access.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@governs-ai/db';
+import { verifySessionToken } from '@/lib/auth-server';
+
+export interface ReportAuthContext {
+  userId: string;
+  orgId: string;
+  roles: string[];
+}
+
+const ADMIN_ROLES = new Set(['ADMIN', 'OWNER']);
+
+export async function resolveReportAuth(
+  request: NextRequest
+): Promise<ReportAuthContext | null> {
+  const authHeader = request.headers.get('authorization');
+  const apiKeyHeader = request.headers.get('x-governs-key');
+  const sessionCookie = request.cookies.get('session')?.value;
+
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length).trim();
+    const session = verifySessionToken(token);
+    if (session) {
+      return {
+        userId: session.sub,
+        orgId: session.orgId,
+        roles: Array.isArray(session.roles) ? session.roles : [],
+      };
+    }
+  }
+
+  if (apiKeyHeader) {
+    const apiKey = await prisma.aPIKey.findFirst({
+      where: { key: apiKeyHeader, isActive: true },
+      select: { userId: true, orgId: true },
+    });
+
+    if (apiKey) {
+      return { userId: apiKey.userId, orgId: apiKey.orgId, roles: [] };
+    }
+  }
+
+  if (sessionCookie) {
+    const session = verifySessionToken(sessionCookie);
+    if (session) {
+      return {
+        userId: session.sub,
+        orgId: session.orgId,
+        roles: Array.isArray(session.roles) ? session.roles : [],
+      };
+    }
+  }
+
+  return null;
+}
+
+export async function requireReportAdmin(
+  auth: ReportAuthContext
+): Promise<{ allowed: boolean }> {
+  const membership = await prisma.orgMembership.findFirst({
+    where: {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      role: { in: ['ADMIN', 'OWNER'] },
+    },
+    select: { role: true },
+  });
+
+  return { allowed: Boolean(membership) };
+}
+
+export function isAdminRole(role: string | null | undefined): boolean {
+  return Boolean(role && ADMIN_ROLES.has(role));
+}

--- a/apps/platform/lib/services/compliance-report-service.ts
+++ b/apps/platform/lib/services/compliance-report-service.ts
@@ -393,11 +393,12 @@ export async function findComplianceReportJob(
 }
 
 export async function queueComplianceReportJob(reportId: string): Promise<void> {
-  queueMicrotask(() => {
+  // Use a later event-loop turn so the API can return 202 before report generation starts.
+  setTimeout(() => {
     processComplianceReportJob(reportId).catch((error) => {
       console.error('Async compliance report generation failed:', error);
     });
-  });
+  }, 0);
 }
 
 export async function processComplianceReportJob(

--- a/apps/platform/lib/services/compliance-report-service.ts
+++ b/apps/platform/lib/services/compliance-report-service.ts
@@ -1,4 +1,7 @@
-import { prisma } from '@governs-ai/db';
+import { prisma, type Prisma } from '@governs-ai/db';
+
+type PrismaTxClient = Prisma.TransactionClient;
+type PrismaWriteClient = typeof prisma | PrismaTxClient;
 
 export type ComplianceReportStatus = 'pending' | 'processing' | 'ready' | 'failed';
 export type ComplianceReportSource = 'on_demand' | 'scheduled';
@@ -359,9 +362,10 @@ function toJobRecord(value: unknown): ComplianceReportJobRecord | null {
 }
 
 export async function createComplianceReportJob(
-  input: ComplianceReportJobInput
+  input: ComplianceReportJobInput,
+  client: PrismaWriteClient = prisma
 ): Promise<ComplianceReportJobRecord> {
-  const created = await prisma.complianceReport.create({
+  const created = await client.complianceReport.create({
     data: {
       orgId: input.orgId,
       requestedById: input.requestedById || null,
@@ -376,29 +380,26 @@ export async function createComplianceReportJob(
   return created as unknown as ComplianceReportJobRecord;
 }
 
+export async function countActiveComplianceReportJobs(
+  orgId: string
+): Promise<number> {
+  return prisma.complianceReport.count({
+    where: {
+      orgId,
+      status: { in: ['pending', 'processing'] },
+    },
+  });
+}
+
 export async function findComplianceReportJob(
   reportId: string,
   orgId: string
 ): Promise<ComplianceReportJobRecord | null> {
-  const report = await prisma.complianceReport.findUnique({
-    where: { id: reportId },
+  const report = await prisma.complianceReport.findFirst({
+    where: { id: reportId, orgId },
   });
 
-  const normalized = toJobRecord(report);
-  if (!normalized || normalized.orgId !== orgId) {
-    return null;
-  }
-
-  return normalized;
-}
-
-export async function queueComplianceReportJob(reportId: string): Promise<void> {
-  // Use a later event-loop turn so the API can return 202 before report generation starts.
-  setTimeout(() => {
-    processComplianceReportJob(reportId).catch((error) => {
-      console.error('Async compliance report generation failed:', error);
-    });
-  }, 0);
+  return toJobRecord(report);
 }
 
 export async function processComplianceReportJob(
@@ -421,13 +422,22 @@ export async function processComplianceReportJob(
     return existing;
   }
 
-  await prisma.complianceReport.update({
-    where: { id: reportId },
+  // Atomic claim: only the call that flips pending|failed -> processing proceeds.
+  // Concurrent callers see count === 0 and short-circuit to the existing row.
+  const claim = await prisma.complianceReport.updateMany({
+    where: {
+      id: reportId,
+      status: { in: ['pending', 'failed'] },
+    },
     data: {
       status: 'processing',
       errorMessage: null,
     },
   });
+
+  if (claim.count === 0) {
+    return existing;
+  }
 
   try {
     const reportJson = await buildComplianceReport({
@@ -447,7 +457,7 @@ export async function processComplianceReportJob(
         generatedAt: new Date(reportJson.generatedAt),
         completedAt: new Date(),
         errorMessage: null,
-        reportJson,
+        reportJson: reportJson as unknown as Prisma.InputJsonValue,
         pdfData,
       },
     });
@@ -455,6 +465,7 @@ export async function processComplianceReportJob(
     return updated as unknown as ComplianceReportJobRecord;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Compliance report generation failed:', error);
     const failed = await prisma.complianceReport.update({
       where: { id: reportId },
       data: {
@@ -478,6 +489,11 @@ export async function ensureComplianceReportJobReady(
   }
 
   if (READY_STATUSES.has(existing.status as ComplianceReportStatus)) {
+    return existing;
+  }
+
+  if (existing.status === 'processing') {
+    // Another worker holds the claim; let the caller poll again.
     return existing;
   }
 

--- a/apps/platform/lib/services/compliance-report-service.ts
+++ b/apps/platform/lib/services/compliance-report-service.ts
@@ -1,0 +1,911 @@
+import { prisma } from '@governs-ai/db';
+
+export type ComplianceReportStatus = 'pending' | 'processing' | 'ready' | 'failed';
+export type ComplianceReportSource = 'on_demand' | 'scheduled';
+export type ComplianceReportFormat = 'pdf' | 'json';
+
+export interface ComplianceReportJobInput {
+  orgId: string;
+  requestedById?: string;
+  startTime?: Date;
+  endTime?: Date;
+  source?: ComplianceReportSource;
+}
+
+export interface ComplianceReportJobRecord {
+  id: string;
+  orgId: string;
+  requestedById: string | null;
+  reportType: string;
+  source: string;
+  status: string;
+  startTime: Date | null;
+  endTime: Date | null;
+  generatedAt: Date | null;
+  completedAt: Date | null;
+  errorMessage: string | null;
+  reportJson: ComplianceSummaryReport | null;
+  pdfData: Buffer | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ComplianceSummaryReport {
+  version: number;
+  reportType: 'compliance_summary';
+  reportId: string;
+  generatedAt: string;
+  orgId: string;
+  period: {
+    startTime: string | null;
+    endTime: string | null;
+  };
+  requestedBy: {
+    userId: string | null;
+    source: ComplianceReportSource;
+  };
+  summary: {
+    policyDecisions: number;
+    piiEvents: number;
+    budgetOverruns: number;
+    userAccessChanges: number;
+    toolInvocations: number;
+  };
+  policyDecisions: {
+    total: number;
+    byDecision: Record<string, number>;
+    averageLatencyMs: number;
+    topTools: Array<{ tool: string; count: number }>;
+    topPolicies: Array<{ policyId: string; count: number }>;
+  };
+  piiEvents: {
+    total: number;
+    contextsDetected: number;
+    contextsRedacted: number;
+    decisionsFlagged: number;
+    uniqueSignals: string[];
+    recentEvents: Array<{
+      source: 'context_memory' | 'decision';
+      timestamp: string;
+      signal: string;
+      action: string;
+    }>;
+  };
+  budget: {
+    overrunCount: number;
+    alertsTriggered: number;
+    totalUsageCost: number;
+    totalPurchaseAmount: number;
+    affectedBudgets: Array<{
+      scope: 'organization' | 'user';
+      userId: string | null;
+      monthlyLimit: number;
+      spendInPeriod: number;
+    }>;
+  };
+  userAccess: {
+    totalMembers: number;
+    newMembers: number;
+    invitesSent: number;
+    roleDistribution: Record<string, number>;
+    recentMembers: Array<{
+      userId: string;
+      email: string;
+      role: string;
+      joinedAt: string;
+    }>;
+  };
+  toolInvocations: {
+    total: number;
+    uniqueTools: number;
+    topTools: Array<{
+      tool: string;
+      count: number;
+      totalCost: number;
+    }>;
+  };
+}
+
+export interface ComplianceReportStatusResponse {
+  report_id: string;
+  status: string;
+  report_type: string;
+  source: string;
+  period: {
+    start_time: string | null;
+    end_time: string | null;
+  };
+  generated_at: string | null;
+  created_at: string;
+  updated_at: string;
+  error: string | null;
+  download_url: string | null;
+  artifacts: {
+    pdf: string | null;
+    json: string | null;
+  };
+}
+
+interface DecisionRow {
+  decision: string;
+  tool: string | null;
+  policyId: string | null;
+  reasons: unknown;
+  latencyMs: number | null;
+  ts: Date;
+}
+
+interface ContextMemoryRow {
+  piiDetected: boolean;
+  piiRedacted: boolean;
+  precheckDecision: string | null;
+  createdAt: Date;
+}
+
+interface BudgetAlertRow {
+  type: string;
+  message: string;
+  createdAt: Date;
+}
+
+interface BudgetLimitRow {
+  type: string;
+  userId: string | null;
+  monthlyLimit: unknown;
+}
+
+interface UsageRecordRow {
+  userId?: string | null;
+  tool: string | null;
+  cost: unknown;
+}
+
+interface PurchaseRecordRow {
+  userId?: string | null;
+  amount: unknown;
+}
+
+interface MembershipRow {
+  userId: string;
+  role: string;
+  createdAt: Date;
+  user: {
+    email: string;
+  };
+}
+
+const READY_STATUSES = new Set<ComplianceReportStatus>(['ready']);
+const PII_HINTS = ['pii', 'pci', 'hipaa', 'email_address', 'phone_number', 'ssn'];
+
+function toDateFilter(startTime?: Date, endTime?: Date): { gte?: Date; lte?: Date } | undefined {
+  const filter: { gte?: Date; lte?: Date } = {};
+
+  if (startTime) {
+    filter.gte = startTime;
+  }
+  if (endTime) {
+    filter.lte = endTime;
+  }
+
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+function toIso(value: Date | null | undefined): string | null {
+  return value ? value.toISOString() : null;
+}
+
+function toNumberValue(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    const toNumber = (value as { toNumber?: () => number }).toNumber;
+    if (typeof toNumber === 'function') {
+      const parsed = toNumber.call(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+  }
+
+  return 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseReasonStrings(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return entry;
+        }
+
+        if (isRecord(entry)) {
+          if (typeof entry.code === 'string') {
+            return entry.code;
+          }
+          return JSON.stringify(entry);
+        }
+
+        return String(entry);
+      })
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (typeof value === 'string') {
+    return [value];
+  }
+
+  if (isRecord(value)) {
+    return [JSON.stringify(value)];
+  }
+
+  return [String(value)];
+}
+
+function extractPiiSignals(reasons: string[]): string[] {
+  const signals = new Set<string>();
+
+  for (const reason of reasons) {
+    const lowered = reason.toLowerCase();
+    if (!PII_HINTS.some((hint) => lowered.includes(hint))) {
+      continue;
+    }
+
+    const signal = reason.includes(':') ? reason.split(':').slice(1).join(':') : reason;
+    signals.add(signal || reason);
+  }
+
+  return Array.from(signals);
+}
+
+function incrementCount(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] || 0) + 1;
+}
+
+function toSortedEntries(counts: Record<string, number>, keyName: 'tool' | 'policyId', limit = 5) {
+  return Object.entries(counts)
+    .sort((left, right) => {
+      if (right[1] !== left[1]) {
+        return right[1] - left[1];
+      }
+      return left[0].localeCompare(right[0]);
+    })
+    .slice(0, limit)
+    .map(([key, count]) => ({ [keyName]: key, count })) as Array<{ [key: string]: string | number }>;
+}
+
+function escapePdfText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/[\r\n]+/g, ' ');
+}
+
+function buildPdfFromLines(lines: string[]): Buffer {
+  const safeLines = lines.slice(0, 300);
+  const startY = 780;
+  const lineHeight = 14;
+
+  const streamParts: string[] = ['BT', '/F1 10 Tf', `50 ${startY} Td`, `${lineHeight} TL`];
+  for (let index = 0; index < safeLines.length; index += 1) {
+    if (index > 0) {
+      streamParts.push('T*');
+    }
+    streamParts.push(`(${escapePdfText(safeLines[index])}) Tj`);
+  }
+  streamParts.push('ET');
+
+  const contentStream = streamParts.join('\n');
+  const objects = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n',
+    '4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+    `5 0 obj\n<< /Length ${Buffer.byteLength(contentStream, 'utf8')} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+  ];
+
+  let pdfBody = '%PDF-1.4\n';
+  const offsets: number[] = [0];
+
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(pdfBody, 'utf8'));
+    pdfBody += object;
+  }
+
+  const xrefStart = Buffer.byteLength(pdfBody, 'utf8');
+  pdfBody += `xref\n0 ${objects.length + 1}\n`;
+  pdfBody += '0000000000 65535 f \n';
+
+  for (let index = 1; index <= objects.length; index += 1) {
+    pdfBody += `${String(offsets[index]).padStart(10, '0')} 00000 n \n`;
+  }
+
+  pdfBody += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdfBody += `startxref\n${xrefStart}\n%%EOF`;
+
+  return Buffer.from(pdfBody, 'utf8');
+}
+
+function buildDownloadUrls(reportId: string): { pdf: string; json: string } {
+  return {
+    pdf: `/api/v1/reports/${reportId}?download=1&format=pdf`,
+    json: `/api/v1/reports/${reportId}?download=1&format=json`,
+  };
+}
+
+function formatCurrency(value: number): string {
+  return value.toFixed(2);
+}
+
+function toJobRecord(value: unknown): ComplianceReportJobRecord | null {
+  if (!value || !isRecord(value)) {
+    return null;
+  }
+
+  return value as unknown as ComplianceReportJobRecord;
+}
+
+export async function createComplianceReportJob(
+  input: ComplianceReportJobInput
+): Promise<ComplianceReportJobRecord> {
+  const created = await prisma.complianceReport.create({
+    data: {
+      orgId: input.orgId,
+      requestedById: input.requestedById || null,
+      reportType: 'compliance_summary',
+      source: input.source || 'on_demand',
+      status: 'pending',
+      startTime: input.startTime,
+      endTime: input.endTime,
+    },
+  });
+
+  return created as unknown as ComplianceReportJobRecord;
+}
+
+export async function findComplianceReportJob(
+  reportId: string,
+  orgId: string
+): Promise<ComplianceReportJobRecord | null> {
+  const report = await prisma.complianceReport.findUnique({
+    where: { id: reportId },
+  });
+
+  const normalized = toJobRecord(report);
+  if (!normalized || normalized.orgId !== orgId) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export async function queueComplianceReportJob(reportId: string): Promise<void> {
+  queueMicrotask(() => {
+    processComplianceReportJob(reportId).catch((error) => {
+      console.error('Async compliance report generation failed:', error);
+    });
+  });
+}
+
+export async function processComplianceReportJob(
+  reportId: string
+): Promise<ComplianceReportJobRecord> {
+  const report = await prisma.complianceReport.findUnique({
+    where: { id: reportId },
+  });
+
+  const existing = toJobRecord(report);
+  if (!existing) {
+    throw new Error('Compliance report not found');
+  }
+
+  if (
+    existing.status === 'ready' &&
+    existing.reportJson &&
+    existing.pdfData
+  ) {
+    return existing;
+  }
+
+  await prisma.complianceReport.update({
+    where: { id: reportId },
+    data: {
+      status: 'processing',
+      errorMessage: null,
+    },
+  });
+
+  try {
+    const reportJson = await buildComplianceReport({
+      reportId: existing.id,
+      orgId: existing.orgId,
+      requestedById: existing.requestedById || undefined,
+      startTime: existing.startTime || undefined,
+      endTime: existing.endTime || undefined,
+      source: (existing.source as ComplianceReportSource) || 'on_demand',
+    });
+
+    const pdfData = complianceReportToPdf(reportJson);
+    const updated = await prisma.complianceReport.update({
+      where: { id: reportId },
+      data: {
+        status: 'ready',
+        generatedAt: new Date(reportJson.generatedAt),
+        completedAt: new Date(),
+        errorMessage: null,
+        reportJson,
+        pdfData,
+      },
+    });
+
+    return updated as unknown as ComplianceReportJobRecord;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    const failed = await prisma.complianceReport.update({
+      where: { id: reportId },
+      data: {
+        status: 'failed',
+        errorMessage: message,
+        completedAt: new Date(),
+      },
+    });
+
+    return failed as unknown as ComplianceReportJobRecord;
+  }
+}
+
+export async function ensureComplianceReportJobReady(
+  reportId: string,
+  orgId: string
+): Promise<ComplianceReportJobRecord | null> {
+  const existing = await findComplianceReportJob(reportId, orgId);
+  if (!existing) {
+    return null;
+  }
+
+  if (READY_STATUSES.has(existing.status as ComplianceReportStatus)) {
+    return existing;
+  }
+
+  if (existing.status === 'failed') {
+    return existing;
+  }
+
+  return processComplianceReportJob(reportId);
+}
+
+export function buildComplianceReportStatus(
+  report: ComplianceReportJobRecord
+): ComplianceReportStatusResponse {
+  const artifacts = report.status === 'ready' ? buildDownloadUrls(report.id) : { pdf: null, json: null };
+
+  return {
+    report_id: report.id,
+    status: report.status,
+    report_type: report.reportType,
+    source: report.source,
+    period: {
+      start_time: toIso(report.startTime),
+      end_time: toIso(report.endTime),
+    },
+    generated_at: toIso(report.generatedAt),
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+    error: report.errorMessage,
+    download_url: artifacts.pdf,
+    artifacts,
+  };
+}
+
+export function getComplianceReportDownload(
+  report: ComplianceReportJobRecord,
+  format: ComplianceReportFormat
+): {
+  body: Buffer | string;
+  contentType: string;
+  filename: string;
+} {
+  if (report.status !== 'ready') {
+    throw new Error('Report is not ready for download');
+  }
+
+  const safeTimestamp = (toIso(report.generatedAt) || report.createdAt.toISOString()).replace(/[:.]/g, '-');
+
+  if (format === 'json') {
+    if (!report.reportJson) {
+      throw new Error('JSON artifact is missing');
+    }
+
+    return {
+      body: JSON.stringify(report.reportJson, null, 2),
+      contentType: 'application/json; charset=utf-8',
+      filename: `compliance-report-${report.orgId}-${safeTimestamp}.json`,
+    };
+  }
+
+  if (!report.pdfData) {
+    throw new Error('PDF artifact is missing');
+  }
+
+  return {
+    body: report.pdfData,
+    contentType: 'application/pdf',
+    filename: `compliance-report-${report.orgId}-${safeTimestamp}.pdf`,
+  };
+}
+
+export function complianceReportToPdf(report: ComplianceSummaryReport): Buffer {
+  const lines: string[] = [
+    'GovernsAI Compliance Summary Report',
+    `Report ID: ${report.reportId}`,
+    `Generated: ${report.generatedAt}`,
+    `Organization: ${report.orgId}`,
+    `Period: ${report.period.startTime || 'N/A'} to ${report.period.endTime || 'N/A'}`,
+    `Requested by: ${report.requestedBy.userId || 'system'} (${report.requestedBy.source})`,
+    '---',
+    `Policy decisions: ${report.summary.policyDecisions}`,
+    `PII events: ${report.summary.piiEvents}`,
+    `Budget overruns: ${report.summary.budgetOverruns}`,
+    `User access changes: ${report.summary.userAccessChanges}`,
+    `Tool invocations: ${report.summary.toolInvocations}`,
+    '---',
+    `Average decision latency (ms): ${report.policyDecisions.averageLatencyMs}`,
+    `Top decision tools: ${report.policyDecisions.topTools.map((item) => `${item.tool} (${item.count})`).join(', ') || 'none'}`,
+    `PII signals: ${report.piiEvents.uniqueSignals.join(', ') || 'none'}`,
+    `Budget alerts triggered: ${report.budget.alertsTriggered}`,
+    `Usage cost: $${formatCurrency(report.budget.totalUsageCost)}`,
+    `Purchase cost: $${formatCurrency(report.budget.totalPurchaseAmount)}`,
+    `Current members: ${report.userAccess.totalMembers}`,
+    `Invites sent: ${report.userAccess.invitesSent}`,
+    `Role distribution: ${Object.entries(report.userAccess.roleDistribution)
+      .map(([role, count]) => `${role}:${count}`)
+      .join(', ') || 'none'}`,
+  ];
+
+  return buildPdfFromLines(lines);
+}
+
+export async function buildComplianceReport(options: {
+  reportId: string;
+  orgId: string;
+  requestedById?: string;
+  startTime?: Date;
+  endTime?: Date;
+  source?: ComplianceReportSource;
+}): Promise<ComplianceSummaryReport> {
+  const dateFilter = toDateFilter(options.startTime, options.endTime);
+
+  const decisionWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { ts: dateFilter } : {}),
+  };
+  const contextWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { createdAt: dateFilter } : {}),
+    OR: [{ piiDetected: true }, { piiRedacted: true }],
+  };
+  const usageWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { timestamp: dateFilter } : {}),
+  };
+  const purchaseWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { timestamp: dateFilter } : {}),
+  };
+  const budgetAlertWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { createdAt: dateFilter } : {}),
+  };
+  const membershipWhere = {
+    orgId: options.orgId,
+    ...(dateFilter ? { createdAt: dateFilter } : {}),
+  };
+  const inviteWhere = {
+    orgId: options.orgId,
+    purpose: 'invite',
+    ...(dateFilter ? { createdAt: dateFilter } : {}),
+  };
+
+  const [
+    rawDecisions,
+    rawContexts,
+    rawBudgetAlerts,
+    rawBudgetLimits,
+    rawUsageRecords,
+    rawPurchaseRecords,
+    rawMembershipsInWindow,
+    rawCurrentMemberships,
+    inviteCount,
+  ] = await Promise.all([
+    prisma.decision.findMany({
+      where: decisionWhere,
+      select: {
+        decision: true,
+        tool: true,
+        policyId: true,
+        reasons: true,
+        latencyMs: true,
+        ts: true,
+      },
+      orderBy: { ts: 'desc' },
+    }),
+    prisma.contextMemory.findMany({
+      where: contextWhere,
+      select: {
+        piiDetected: true,
+        piiRedacted: true,
+        precheckDecision: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.budgetAlert.findMany({
+      where: budgetAlertWhere,
+      select: {
+        type: true,
+        message: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.budgetLimit.findMany({
+      where: {
+        orgId: options.orgId,
+        isActive: true,
+      },
+      select: {
+        type: true,
+        userId: true,
+        monthlyLimit: true,
+      },
+    }),
+    prisma.usageRecord.findMany({
+      where: usageWhere,
+      select: {
+        userId: true,
+        tool: true,
+        cost: true,
+      },
+      orderBy: { timestamp: 'desc' },
+    }),
+    prisma.purchaseRecord.findMany({
+      where: purchaseWhere,
+      select: {
+        userId: true,
+        amount: true,
+      },
+      orderBy: { timestamp: 'desc' },
+    }),
+    prisma.orgMembership.findMany({
+      where: membershipWhere,
+      select: {
+        userId: true,
+        role: true,
+        createdAt: true,
+        user: {
+          select: {
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.orgMembership.findMany({
+      where: {
+        orgId: options.orgId,
+      },
+      select: {
+        userId: true,
+        role: true,
+        createdAt: true,
+        user: {
+          select: {
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.verificationToken.count({
+      where: inviteWhere,
+    }),
+  ]);
+
+  const decisions = rawDecisions as unknown as DecisionRow[];
+  const contexts = rawContexts as unknown as ContextMemoryRow[];
+  const budgetAlerts = rawBudgetAlerts as unknown as BudgetAlertRow[];
+  const budgetLimits = rawBudgetLimits as unknown as BudgetLimitRow[];
+  const usageRecords = rawUsageRecords as unknown as UsageRecordRow[];
+  const purchaseRecords = rawPurchaseRecords as unknown as PurchaseRecordRow[];
+  const membershipsInWindow = rawMembershipsInWindow as unknown as MembershipRow[];
+  const currentMemberships = rawCurrentMemberships as unknown as MembershipRow[];
+
+  const byDecision: Record<string, number> = {};
+  const toolCounts: Record<string, number> = {};
+  const policyCounts: Record<string, number> = {};
+  let totalLatency = 0;
+  let latencySamples = 0;
+  const recentPiiEvents: ComplianceSummaryReport['piiEvents']['recentEvents'] = [];
+  const piiSignals = new Set<string>();
+  let piiDecisionEvents = 0;
+
+  for (const decision of decisions) {
+    incrementCount(byDecision, decision.decision);
+
+    if (decision.tool) {
+      incrementCount(toolCounts, decision.tool);
+    }
+
+    incrementCount(policyCounts, decision.policyId || 'unassigned');
+
+    if (typeof decision.latencyMs === 'number' && Number.isFinite(decision.latencyMs)) {
+      totalLatency += decision.latencyMs;
+      latencySamples += 1;
+    }
+
+    const reasons = parseReasonStrings(decision.reasons);
+    const decisionSignals = extractPiiSignals(reasons);
+    if (decisionSignals.length > 0) {
+      piiDecisionEvents += 1;
+      for (const signal of decisionSignals) {
+        piiSignals.add(signal);
+        if (recentPiiEvents.length < 10) {
+          recentPiiEvents.push({
+            source: 'decision',
+            timestamp: decision.ts.toISOString(),
+            signal,
+            action: decision.decision,
+          });
+        }
+      }
+    }
+  }
+
+  let contextsDetected = 0;
+  let contextsRedacted = 0;
+  for (const context of contexts) {
+    if (context.piiDetected) {
+      contextsDetected += 1;
+      if (recentPiiEvents.length < 10) {
+        recentPiiEvents.push({
+          source: 'context_memory',
+          timestamp: context.createdAt.toISOString(),
+          signal: context.piiRedacted ? 'pii_redacted' : 'pii_detected',
+          action: context.precheckDecision || 'stored',
+        });
+      }
+    }
+    if (context.piiRedacted) {
+      contextsRedacted += 1;
+    }
+  }
+
+  const usageByTool = new Map<string, { count: number; totalCost: number }>();
+  for (const usage of usageRecords) {
+    const tool = usage.tool || 'unknown';
+    const current = usageByTool.get(tool) || { count: 0, totalCost: 0 };
+    current.count += 1;
+    current.totalCost += toNumberValue(usage.cost);
+    usageByTool.set(tool, current);
+  }
+
+  const totalUsageCost = usageRecords.reduce((sum, item) => sum + toNumberValue(item.cost), 0);
+  const totalPurchaseAmount = purchaseRecords.reduce((sum, item) => sum + toNumberValue(item.amount), 0);
+
+  const overrunBudgets = budgetLimits
+    .map((limit) => {
+      const spendInPeriod =
+        limit.type === 'user' && limit.userId
+          ? usageRecords
+              .filter((record) => record.userId === limit.userId)
+              .reduce((sum, record) => sum + toNumberValue(record.cost), 0) +
+            purchaseRecords
+              .filter((record) => record.userId === limit.userId)
+              .reduce((sum, record) => sum + toNumberValue(record.amount), 0)
+          : totalUsageCost + totalPurchaseAmount;
+
+      return {
+        scope: (limit.type === 'user' ? 'user' : 'organization') as 'organization' | 'user',
+        userId: limit.userId,
+        monthlyLimit: toNumberValue(limit.monthlyLimit),
+        spendInPeriod,
+      };
+    })
+    .filter((limit) => limit.monthlyLimit > 0 && limit.spendInPeriod > limit.monthlyLimit);
+
+  const roleDistribution: Record<string, number> = {};
+  for (const membership of currentMemberships) {
+    incrementCount(roleDistribution, membership.role);
+  }
+
+  const recentMembers = membershipsInWindow.slice(0, 10).map((membership) => ({
+    userId: membership.userId,
+    email: membership.user.email,
+    role: membership.role,
+    joinedAt: membership.createdAt.toISOString(),
+  }));
+
+  const topTools = Object.entries(toolCounts)
+    .sort((left, right) => {
+      if (right[1] !== left[1]) {
+        return right[1] - left[1];
+      }
+      return left[0].localeCompare(right[0]);
+    })
+    .slice(0, 5)
+    .map(([tool, count]) => ({
+      tool,
+      count,
+      totalCost: usageByTool.get(tool)?.totalCost || 0,
+    }));
+
+  return {
+    version: 1,
+    reportType: 'compliance_summary',
+    reportId: options.reportId,
+    generatedAt: new Date().toISOString(),
+    orgId: options.orgId,
+    period: {
+      startTime: toIso(options.startTime),
+      endTime: toIso(options.endTime),
+    },
+    requestedBy: {
+      userId: options.requestedById || null,
+      source: options.source || 'on_demand',
+    },
+    summary: {
+      policyDecisions: decisions.length,
+      piiEvents: contextsDetected + piiDecisionEvents,
+      budgetOverruns: overrunBudgets.length,
+      userAccessChanges: membershipsInWindow.length + Number(inviteCount || 0),
+      toolInvocations: decisions.filter((decision) => Boolean(decision.tool)).length,
+    },
+    policyDecisions: {
+      total: decisions.length,
+      byDecision,
+      averageLatencyMs: latencySamples > 0 ? Math.round(totalLatency / latencySamples) : 0,
+      topTools: toSortedEntries(toolCounts, 'tool') as Array<{ tool: string; count: number }>,
+      topPolicies: toSortedEntries(policyCounts, 'policyId') as Array<{ policyId: string; count: number }>,
+    },
+    piiEvents: {
+      total: contextsDetected + piiDecisionEvents,
+      contextsDetected,
+      contextsRedacted,
+      decisionsFlagged: piiDecisionEvents,
+      uniqueSignals: Array.from(piiSignals).sort((left, right) => left.localeCompare(right)),
+      recentEvents: recentPiiEvents,
+    },
+    budget: {
+      overrunCount: overrunBudgets.length,
+      alertsTriggered: budgetAlerts.length,
+      totalUsageCost,
+      totalPurchaseAmount,
+      affectedBudgets: overrunBudgets,
+    },
+    userAccess: {
+      totalMembers: currentMemberships.length,
+      newMembers: membershipsInWindow.length,
+      invitesSent: Number(inviteCount || 0),
+      roleDistribution,
+      recentMembers,
+    },
+    toolInvocations: {
+      total: decisions.filter((decision) => Boolean(decision.tool)).length,
+      uniqueTools: Object.keys(toolCounts).length,
+      topTools,
+    },
+  };
+}

--- a/packages/db/migrations/20260424144000_add_compliance_reports/migration.sql
+++ b/packages/db/migrations/20260424144000_add_compliance_reports/migration.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "compliance_reports" (
+    "id" TEXT NOT NULL,
+    "org_id" TEXT NOT NULL,
+    "requested_by_id" TEXT,
+    "report_type" TEXT NOT NULL DEFAULT 'compliance_summary',
+    "source" TEXT NOT NULL DEFAULT 'on_demand',
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "start_time" TIMESTAMP(3),
+    "end_time" TIMESTAMP(3),
+    "generated_at" TIMESTAMP(3),
+    "completed_at" TIMESTAMP(3),
+    "error_message" TEXT,
+    "report_json" JSONB,
+    "pdf_data" BYTEA,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "compliance_reports_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "compliance_reports_org_id_created_at_idx"
+ON "compliance_reports"("org_id", "created_at" DESC);
+
+CREATE INDEX "compliance_reports_status_created_at_idx"
+ON "compliance_reports"("status", "created_at" DESC);
+
+CREATE INDEX "compliance_reports_requested_by_id_created_at_idx"
+ON "compliance_reports"("requested_by_id", "created_at" DESC);
+
+ALTER TABLE "compliance_reports"
+ADD CONSTRAINT "compliance_reports_org_id_fkey"
+FOREIGN KEY ("org_id") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "compliance_reports"
+ADD CONSTRAINT "compliance_reports_requested_by_id_fkey"
+FOREIGN KEY ("requested_by_id") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -37,6 +37,7 @@ model Org {
   documents            Document[]
   refragAnalytics     RefragAnalytics[]
   keycloakSyncJobs     KeycloakSyncJob[]
+  complianceReports    ComplianceReport[]
 }
 
 model User {
@@ -70,6 +71,7 @@ model User {
   refragAnalytics     RefragAnalytics[]
   keycloakSyncState    KeycloakSyncState?
   keycloakSyncJobs     KeycloakSyncJob[]
+  complianceReports    ComplianceReport[]
 }
 
 model Credential {
@@ -376,6 +378,31 @@ model AuditLog {
   @@index([userId, createdAt])
   @@index([orgId, createdAt])
   @@index([action, createdAt])
+}
+
+model ComplianceReport {
+  id            String    @id @default(cuid())
+  orgId         String    @map("org_id")
+  requestedById String?   @map("requested_by_id")
+  reportType    String    @default("compliance_summary") @map("report_type")
+  source        String    @default("on_demand")
+  status        String    @default("pending")
+  startTime     DateTime? @map("start_time")
+  endTime       DateTime? @map("end_time")
+  generatedAt   DateTime? @map("generated_at")
+  completedAt   DateTime? @map("completed_at")
+  errorMessage  String?   @map("error_message")
+  reportJson    Json?     @map("report_json")
+  pdfData       Bytes?    @map("pdf_data")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+  org           Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  requestedBy   User?     @relation(fields: [requestedById], references: [id], onDelete: SetNull)
+
+  @@index([orgId, createdAt(sort: Desc)])
+  @@index([status, createdAt(sort: Desc)])
+  @@index([requestedById, createdAt(sort: Desc)])
+  @@map("compliance_reports")
 }
 
 model Policy {


### PR DESCRIPTION
## Summary
- add persisted compliance report jobs plus PDF/JSON artifact generation
- add versioned async report APIs at /api/v1/reports/generate and /api/v1/reports/:id
- document the contract and cover it with Jest route/service tests
- defer background report processing to a later event-loop turn so POST /generate can return 202 before work starts

## GovernsAI Tracker issue
GOV-603

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] pnpm --filter @governs-ai/platform test -- --runTestsByPath __tests__/api/reports.test.ts __tests__/lib/compliance-report-service.test.ts
- [ ] pnpm --filter @governs-ai/platform build
  Current branch build is still blocked by existing platform issues outside GOV-603: the pdf-parse import warning in lib/services/ocr-service.ts and a Next pages-manifest.json failure during page-data collection.