### PR TITLE
ci: remove gitleaks secret-scan job (ADR-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,3 @@ jobs:
         run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci_db
-
-  secret-scan:
-    name: Secret Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove the `secret-scan` job from `.github/workflows/ci.yml` that ran `gitleaks/gitleaks-action@v2`.
- ADR-001 mandates GitHub-native secret scanning only — never gitleaks or alternatives.
- GitHub-native secret scanning is already enabled at the repo level and covers this surface.
- No other CI jobs or triggers are touched. No branch-protection changes (reconciled in GOV-1854).

## GovernsAI Tracker issue
GOV-1865

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [ ] `lint-and-typecheck`, `unit-test`, `build` jobs continue to run on PR/push to main.
- [ ] No `gitleaks` references remain in `.github/workflows/*.yml`.
- [ ] PR passes remaining required checks.