### PR TITLE
fix(reports): sanitize compliance report error response (GOV-1885 item 5)

### DIFF
--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -191,6 +191,7 @@ Ready response shape:
 {
   "report_id": "cuid",
   "status": "ready",
+  "error_code": null,
   "download_url": "/api/v1/reports/cuid?download=1&format=pdf",
   "artifacts": {
     "pdf": "/api/v1/reports/cuid?download=1&format=pdf",
@@ -198,6 +199,12 @@ Ready response shape:
   }
 }
 ```
+
+Failed jobs return `status: "failed"` with `error_code: "generation_failed"`.
+The raw failure message is intentionally **not** exposed on the status path —
+it's persisted on the `compliance_reports.errorMessage` row and emitted via
+`console.error` for ops/Sentry. Clients should branch on `error_code`, not
+on the absence of `download_url`.
 
 Artifact downloads:
 

--- a/apps/platform/__tests__/api/reports.test.ts
+++ b/apps/platform/__tests__/api/reports.test.ts
@@ -122,7 +122,7 @@ describe('reports API', () => {
         generated_at: null,
         created_at: '2026-04-24T15:00:00.000Z',
         updated_at: '2026-04-24T15:00:00.000Z',
-        error: null,
+        error_code: null,
         download_url: null,
         artifacts: { pdf: null, json: null },
       });
@@ -255,7 +255,7 @@ describe('reports API', () => {
         generated_at: '2026-04-24T15:00:00.000Z',
         created_at: '2026-04-24T15:00:00.000Z',
         updated_at: '2026-04-24T15:00:01.000Z',
-        error: null,
+        error_code: null,
         download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
         artifacts: {
           pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',

--- a/apps/platform/__tests__/lib/compliance-report-service.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-service.test.ts
@@ -347,5 +347,37 @@ describe('compliance-report-service', () => {
       pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
       json: '/api/v1/reports/rpt_ready?download=1&format=json',
     });
+    expect(payload.error_code).toBeNull();
+  });
+
+  it('returns a generic error_code for failed jobs and never leaks the raw errorMessage', () => {
+    const payload = buildComplianceReportStatus({
+      id: 'rpt_failed',
+      orgId: 'org-1',
+      requestedById: 'user-1',
+      reportType: 'compliance_summary',
+      source: 'on_demand',
+      status: 'failed',
+      startTime: null,
+      endTime: null,
+      generatedAt: null,
+      completedAt: new Date('2026-04-24T15:00:01.000Z'),
+      // Raw message simulates anything that could leak (DB connection strings,
+      // internal hostnames, stack-trace fragments). It must NOT round-trip.
+      errorMessage:
+        'getaddrinfo ENOTFOUND prisma-prod.internal:5432 — connection refused',
+      reportJson: null,
+      pdfData: null,
+      createdAt: new Date('2026-04-24T14:59:00.000Z'),
+      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+    });
+
+    expect(payload.status).toBe('failed');
+    expect(payload.error_code).toBe('generation_failed');
+    expect(payload.download_url).toBeNull();
+    expect(payload.artifacts).toEqual({ pdf: null, json: null });
+    expect(JSON.stringify(payload)).not.toContain('prisma-prod.internal');
+    expect(JSON.stringify(payload)).not.toContain('ENOTFOUND');
+    expect(payload).not.toHaveProperty('error');
   });
 });

--- a/apps/platform/lib/services/compliance-report-service.ts
+++ b/apps/platform/lib/services/compliance-report-service.ts
@@ -109,6 +109,8 @@ export interface ComplianceSummaryReport {
   };
 }
 
+export type ComplianceReportErrorCode = 'generation_failed';
+
 export interface ComplianceReportStatusResponse {
   report_id: string;
   status: string;
@@ -121,7 +123,7 @@ export interface ComplianceReportStatusResponse {
   generated_at: string | null;
   created_at: string;
   updated_at: string;
-  error: string | null;
+  error_code: ComplianceReportErrorCode | null;
   download_url: string | null;
   artifacts: {
     pdf: string | null;
@@ -504,6 +506,12 @@ export async function ensureComplianceReportJobReady(
   return processComplianceReportJob(reportId);
 }
 
+function toClientErrorCode(
+  status: string
+): ComplianceReportErrorCode | null {
+  return status === 'failed' ? 'generation_failed' : null;
+}
+
 export function buildComplianceReportStatus(
   report: ComplianceReportJobRecord
 ): ComplianceReportStatusResponse {
@@ -521,7 +529,7 @@ export function buildComplianceReportStatus(
     generated_at: toIso(report.generatedAt),
     created_at: report.createdAt.toISOString(),
     updated_at: report.updatedAt.toISOString(),
-    error: report.errorMessage,
+    error_code: toClientErrorCode(report.status),
     download_url: artifacts.pdf,
     artifacts,
   };


### PR DESCRIPTION
## Summary

Address item (5) from [GOV-1885](https://github.com/Governs-AI/governsai-console/issues) — Cipher's review feedback on the compliance report status path.

`buildComplianceReportStatus` previously returned `error: report.errorMessage` from the DB row. That path leaks anything the catch handler stored — DB hostnames, connection strings, stack-trace fragments — to any caller polling a `failed` job. Route-level 500s already returned generic strings; this closes the residual leak on the status path.

### What changed

- `ComplianceReportStatusResponse` no longer carries `error: string | null`.
- Adds `error_code: 'generation_failed' | null`. Only `failed` jobs receive a non-null code.
- Raw `errorMessage` continues to be persisted on `compliance_reports.errorMessage` (DB) and emitted via `console.error` for ops/Sentry — the storage side of Cipher's recommendation is already in place.
- README API contract updated to document the sanitized shape and the rationale.

### Tests

- Existing `compliance-report-service` and `reports` API suites updated to match the new response field.
- New regression test in `compliance-report-service.test.ts` builds a status payload from a job with a representative leaky error (`getaddrinfo ENOTFOUND prisma-prod.internal:5432 — connection refused`) and asserts:
  - `payload.error_code === 'generation_failed'`
  - The raw substrings (`prisma-prod.internal`, `ENOTFOUND`) do not appear anywhere in the serialized payload
  - The legacy `error` property is not present

```
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

`tsc --noEmit` clean.

## GovernsAI Tracker issue

[GOV-1885](mention://issue/cce4c323-3051-4c05-a748-8fa87821b4af) (parent: [GOV-603](mention://issue/6efdbd7e-563c-41b4-9a6d-90408e8a4949))

This PR closes acceptance criterion (5) only. Items (6)–(9) (Blob storage migration, PII tagging, processing-zombie reclaim, TOCTOU mitigation) remain open on GOV-1885 and will be split into follow-up PRs.

## Reviewers

Tagging @Nexus (code quality) and @Cipher (security/arch) — both approvals required.

## Test plan

- [x] Unit — `buildComplianceReportStatus` returns `error_code: null` for non-failed states
- [x] Unit — `buildComplianceReportStatus` returns `error_code: 'generation_failed'` for failed jobs and never serializes the raw message
- [x] API contract test — generate/poll mocks updated to the sanitized shape
- [x] `tsc --noEmit` clean across the platform app
- [ ] (manual) Failed-job poll in dev: trigger a forced failure (e.g. throw inside `buildComplianceReport`) and confirm `GET /api/v1/reports/:id` returns only `error_code` — no `errorMessage` text