### PR TITLE
feat(compliance): GOV-603 follow-ups — report generation hardening

### DIFF
--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -191,6 +191,7 @@ Ready response shape:
 {
   "report_id": "cuid",
   "status": "ready",
+  "error_code": null,
   "download_url": "/api/v1/reports/cuid?download=1&format=pdf",
   "artifacts": {
     "pdf": "/api/v1/reports/cuid?download=1&format=pdf",
@@ -199,12 +200,51 @@ Ready response shape:
 }
 ```
 
+Failed response shape (sanitized — raw error message is logged server-side
+only and never returned by the public API):
+
+```json
+{
+  "report_id": "cuid",
+  "status": "failed",
+  "error_code": "generation_failed",
+  "download_url": null,
+  "artifacts": { "pdf": null, "json": null }
+}
+```
+
+`error_code` enum: `generation_failed` (the only public failure code today).
+
 Artifact downloads:
 
 ```http
 GET /api/v1/reports/:report_id?download=1&format=pdf
 GET /api/v1/reports/:report_id?download=1&format=json
 ```
+
+**Storage:** rendered PDFs are persisted to Vercel Blob and served back through
+`/api/v1/reports/:id?download=1&format=pdf` so the admin gate and audit log
+remain authoritative. Set `BLOB_READ_WRITE_TOKEN` for production. When the env
+is missing, the service falls back to inline `pdf_data` in Postgres so dev and
+test environments keep working without external dependencies.
+
+**PII / retention:** every `compliance_reports` row carries `contains_pii=true`
+by default because the report schema persists member emails and PII signal
+events. Retention and legal-hold workflows must respect this column; the audit
+log entry for `compliance.report.download` includes `containsPii` and the
+storage backend (`blob` vs `inline`).
+
+**Stale-job recovery:** `processComplianceReportJob` reclaims rows that are
+stuck in `processing` for longer than 15 minutes (a worker that died between
+the claim and the final write). Active claims still short-circuit concurrent
+callers, so this is safe to run from a watchdog cron.
+
+**Concurrency cap (TOCTOU note):** the `count + create` pair in
+`POST /generate` is intentionally not atomic. Worst-case overshoot is
+`cap + concurrent_admin_count` rows, briefly. With ADMIN/OWNER-only access and
+a default cap of 3, the race is acceptable; if the cap is later raised or
+opened to non-admin roles, replace the count check with a partial unique index
+or wrap it in a `RAISE`-on-cap CTE.
 
 ## 🔗 Related Packages
 

--- a/apps/platform/README.md
+++ b/apps/platform/README.md
@@ -228,6 +228,17 @@ remain authoritative. Set `BLOB_READ_WRITE_TOKEN` for production. When the env
 is missing, the service falls back to inline `pdf_data` in Postgres so dev and
 test environments keep working without external dependencies.
 
+**Encryption-at-rest:** PDFs are encrypted with AES-256-GCM before they reach
+Vercel Blob, so a leaked blob URL alone (server log, referer header, error
+report, MITM on the inter-service fetch) is not sufficient to disclose PII —
+the bytes at rest are opaque ciphertext. Set
+`COMPLIANCE_REPORT_ENCRYPTION_KEY` to a 64-character hex string (32 bytes,
+e.g. `openssl rand -hex 32`) whenever `BLOB_READ_WRITE_TOKEN` is set; the
+storage layer fails closed if the key is missing or malformed. Rotate the key
+by re-running `scripts/backfill-compliance-report-blobs.ts` against the new
+key (the magic header lets future migrations decrypt with the previous key
+during transition).
+
 **PII / retention:** every `compliance_reports` row carries `contains_pii=true`
 by default because the report schema persists member emails and PII signal
 events. Retention and legal-hold workflows must respect this column; the audit

--- a/apps/platform/__mocks__/vercel-blob.ts
+++ b/apps/platform/__mocks__/vercel-blob.ts
@@ -1,0 +1,26 @@
+/**
+ * Manual stub for @vercel/blob in jest.
+ * Real uploads happen against the Vercel Blob service in dev/prod; tests must
+ * never exercise the network. Each fn is a jest.fn() so individual tests can
+ * assert on calls or override return values.
+ */
+
+export const put = jest.fn(async (pathname: string, _body: Buffer | Uint8Array | string) => ({
+  url: `https://blob.test.local/${pathname}-suffix`,
+  pathname: `${pathname}-suffix`,
+  contentType: 'application/pdf',
+  contentDisposition: 'inline',
+  downloadUrl: `https://blob.test.local/${pathname}-suffix?download=1`,
+}));
+
+export const del = jest.fn(async () => undefined);
+
+export const head = jest.fn();
+
+export type PutBlobResult = {
+  url: string;
+  pathname: string;
+  contentType: string;
+  contentDisposition: string;
+  downloadUrl: string;
+};

--- a/apps/platform/__tests__/api/reports.test.ts
+++ b/apps/platform/__tests__/api/reports.test.ts
@@ -76,8 +76,12 @@ const pendingReport = {
   generatedAt: null,
   completedAt: null,
   errorMessage: null,
+  errorCode: null,
   reportJson: null,
   pdfData: null,
+  pdfBlobUrl: null,
+  pdfBlobPath: null,
+  containsPii: true,
   createdAt: new Date('2026-04-24T15:00:00.000Z'),
   updatedAt: new Date('2026-04-24T15:00:00.000Z'),
 };
@@ -89,7 +93,10 @@ const readyReport = {
   generatedAt: new Date('2026-04-24T15:00:00.000Z'),
   completedAt: new Date('2026-04-24T15:00:01.000Z'),
   reportJson: { ok: true },
-  pdfData: Buffer.from('%PDF-1.4'),
+  pdfData: null,
+  pdfBlobUrl: 'https://blob.test.local/compliance-reports/org-1/rpt_ready.pdf-suffix',
+  pdfBlobPath: 'compliance-reports/org-1/rpt_ready.pdf-suffix',
+  containsPii: true,
   updatedAt: new Date('2026-04-24T15:00:01.000Z'),
 };
 
@@ -122,7 +129,7 @@ describe('reports API', () => {
         generated_at: null,
         created_at: '2026-04-24T15:00:00.000Z',
         updated_at: '2026-04-24T15:00:00.000Z',
-        error: null,
+        error_code: null,
         download_url: null,
         artifacts: { pdf: null, json: null },
       });
@@ -255,7 +262,7 @@ describe('reports API', () => {
         generated_at: '2026-04-24T15:00:00.000Z',
         created_at: '2026-04-24T15:00:00.000Z',
         updated_at: '2026-04-24T15:00:01.000Z',
-        error: null,
+        error_code: null,
         download_url: '/api/v1/reports/rpt_ready?download=1&format=pdf',
         artifacts: {
           pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
@@ -287,7 +294,7 @@ describe('reports API', () => {
     it('downloads the generated JSON artifact once the job is ready', async () => {
       setAdminMembership();
       mockEnsureReady.mockResolvedValue(readyReport);
-      mockGetDownload.mockReturnValue({
+      mockGetDownload.mockResolvedValue({
         body: JSON.stringify({ ok: true }),
         contentType: 'application/json; charset=utf-8',
         filename: 'report.json',
@@ -311,6 +318,42 @@ describe('reports API', () => {
             action: 'compliance.report.download',
             orgId: 'org-1',
             userId: 'user-1',
+            details: expect.objectContaining({
+              reportId: 'rpt_ready',
+              format: 'json',
+              containsPii: true,
+              storage: 'blob',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('downloads the generated PDF from blob storage when pdfBlobUrl is present', async () => {
+      setAdminMembership();
+      mockEnsureReady.mockResolvedValue(readyReport);
+      mockGetDownload.mockResolvedValue({
+        body: Buffer.from('%PDF-1.4 from-blob'),
+        contentType: 'application/pdf',
+        filename: 'report.pdf',
+      });
+
+      const req = new NextRequest(
+        'http://localhost/api/v1/reports/rpt_ready?download=1&format=pdf',
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${makeToken('OWNER')}` },
+        }
+      );
+
+      const res = await GET(req, { params: Promise.resolve({ id: 'rpt_ready' }) });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('application/pdf');
+      expect(mockGetDownload).toHaveBeenCalledWith(readyReport, 'pdf');
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            details: expect.objectContaining({ storage: 'blob' }),
           }),
         })
       );

--- a/apps/platform/__tests__/lib/compliance-report-service.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-service.test.ts
@@ -272,6 +272,8 @@ describe('compliance-report-service', () => {
 
   it('processComplianceReportJob proceeds when the atomic claim succeeds and persists the PDF to blob storage', async () => {
     process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_test_token';
+    // Encryption-at-rest key — required when blob storage is enabled.
+    process.env.COMPLIANCE_REPORT_ENCRYPTION_KEY = '0'.repeat(64);
 
     const jobRow = baseRow({ id: 'rpt_claimed', status: 'pending' });
     mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
@@ -319,6 +321,7 @@ describe('compliance-report-service', () => {
     );
 
     delete process.env.BLOB_READ_WRITE_TOKEN;
+    delete process.env.COMPLIANCE_REPORT_ENCRYPTION_KEY;
   });
 
   it('processComplianceReportJob falls back to inline pdfData when blob storage is not configured', async () => {

--- a/apps/platform/__tests__/lib/compliance-report-service.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-service.test.ts
@@ -6,9 +6,35 @@ import {
   countActiveComplianceReportJobs,
   findComplianceReportJob,
   processComplianceReportJob,
+  STALE_PROCESSING_MS,
 } from '@/lib/services/compliance-report-service';
 
 const mockPrisma = prisma as any;
+
+function baseRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'rpt_x',
+    orgId: 'org-1',
+    requestedById: 'user-1',
+    reportType: 'compliance_summary',
+    source: 'on_demand',
+    status: 'pending',
+    startTime: null,
+    endTime: null,
+    generatedAt: null,
+    completedAt: null,
+    errorMessage: null,
+    errorCode: null,
+    reportJson: null,
+    pdfData: null,
+    pdfBlobUrl: null,
+    pdfBlobPath: null,
+    containsPii: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
 
 describe('compliance-report-service', () => {
   beforeEach(() => {
@@ -205,23 +231,7 @@ describe('compliance-report-service', () => {
   });
 
   it('scopes findComplianceReportJob lookups by orgId at the database boundary', async () => {
-    mockPrisma.complianceReport.findFirst.mockResolvedValue({
-      id: 'rpt_x',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'pending',
-      startTime: null,
-      endTime: null,
-      generatedAt: null,
-      completedAt: null,
-      errorMessage: null,
-      reportJson: null,
-      pdfData: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    mockPrisma.complianceReport.findFirst.mockResolvedValue(baseRow({ id: 'rpt_x' }));
 
     const result = await findComplianceReportJob('rpt_x', 'org-1');
 
@@ -246,23 +256,9 @@ describe('compliance-report-service', () => {
   });
 
   it('processComplianceReportJob short-circuits when the atomic claim is lost (already processing)', async () => {
-    mockPrisma.complianceReport.findUnique.mockResolvedValue({
-      id: 'rpt_locked',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'processing',
-      startTime: null,
-      endTime: null,
-      generatedAt: null,
-      completedAt: null,
-      errorMessage: null,
-      reportJson: null,
-      pdfData: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    mockPrisma.complianceReport.findUnique.mockResolvedValue(
+      baseRow({ id: 'rpt_locked', status: 'processing' })
+    );
     mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 0 });
 
     const result = await processComplianceReportJob('rpt_locked');
@@ -274,25 +270,10 @@ describe('compliance-report-service', () => {
     expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
   });
 
-  it('processComplianceReportJob proceeds when the atomic claim succeeds', async () => {
-    const jobRow = {
-      id: 'rpt_claimed',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'pending',
-      startTime: null,
-      endTime: null,
-      generatedAt: null,
-      completedAt: null,
-      errorMessage: null,
-      reportJson: null,
-      pdfData: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+  it('processComplianceReportJob proceeds when the atomic claim succeeds and persists the PDF to blob storage', async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_test_token';
 
+    const jobRow = baseRow({ id: 'rpt_claimed', status: 'pending' });
     mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
     mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 1 });
     mockPrisma.complianceReport.update.mockResolvedValue({ ...jobRow, status: 'ready' });
@@ -309,43 +290,185 @@ describe('compliance-report-service', () => {
 
     await processComplianceReportJob('rpt_claimed');
 
-    expect(mockPrisma.complianceReport.updateMany).toHaveBeenCalledWith({
-      where: { id: 'rpt_claimed', status: { in: ['pending', 'failed'] } },
-      data: { status: 'processing', errorMessage: null },
-    });
+    // Claim accepts pending|failed plus stale-processing reclaim.
+    expect(mockPrisma.complianceReport.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'rpt_claimed',
+          OR: expect.arrayContaining([
+            { status: { in: ['pending', 'failed'] } },
+            expect.objectContaining({ status: 'processing' }),
+          ]),
+        }),
+        data: { status: 'processing', errorMessage: null, errorCode: null },
+      })
+    );
+
+    // Successful run writes blob URL and clears inline pdfData.
     expect(mockPrisma.complianceReport.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'rpt_claimed' },
-        data: expect.objectContaining({ status: 'ready' }),
+        data: expect.objectContaining({
+          status: 'ready',
+          pdfBlobUrl: expect.stringContaining('blob.test.local'),
+          pdfBlobPath: expect.stringContaining('compliance-reports/org-1/rpt_claimed.pdf'),
+          pdfData: null,
+          containsPii: true,
+        }),
+      })
+    );
+
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+  });
+
+  it('processComplianceReportJob falls back to inline pdfData when blob storage is not configured', async () => {
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+
+    const jobRow = baseRow({ id: 'rpt_inline', status: 'pending' });
+    mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
+    mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.complianceReport.update.mockResolvedValue({ ...jobRow, status: 'ready' });
+
+    mockPrisma.decision.findMany.mockResolvedValue([]);
+    mockPrisma.contextMemory.findMany.mockResolvedValue([]);
+    mockPrisma.budgetAlert.findMany.mockResolvedValue([]);
+    mockPrisma.budgetLimit.findMany.mockResolvedValue([]);
+    mockPrisma.usageRecord.findMany.mockResolvedValue([]);
+    mockPrisma.purchaseRecord.findMany.mockResolvedValue([]);
+    mockPrisma.orgMembership.findMany.mockResolvedValue([]);
+    mockPrisma.verificationToken.count.mockResolvedValue(0);
+
+    await processComplianceReportJob('rpt_inline');
+
+    expect(mockPrisma.complianceReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'rpt_inline' },
+        data: expect.objectContaining({
+          status: 'ready',
+          pdfBlobUrl: null,
+          pdfBlobPath: null,
+          pdfData: expect.any(Buffer),
+        }),
       })
     );
   });
 
-  it('publishes status payloads with artifact URLs once the report is ready', () => {
-    const payload = buildComplianceReportStatus({
-      id: 'rpt_ready',
-      orgId: 'org-1',
-      requestedById: 'user-1',
-      reportType: 'compliance_summary',
-      source: 'on_demand',
-      status: 'ready',
-      startTime: new Date('2026-04-01T00:00:00.000Z'),
-      endTime: new Date('2026-04-24T00:00:00.000Z'),
-      generatedAt: new Date('2026-04-24T15:00:00.000Z'),
-      completedAt: new Date('2026-04-24T15:00:01.000Z'),
-      errorMessage: null,
-      reportJson: null,
-      pdfData: Buffer.from('%PDF-1.4'),
-      createdAt: new Date('2026-04-24T14:59:00.000Z'),
-      updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+  it('processComplianceReportJob writes a sanitized error_code on failure and keeps the raw message internal', async () => {
+    const jobRow = baseRow({ id: 'rpt_err', status: 'pending' });
+    mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
+    mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 1 });
+
+    // Force the build pipeline to throw a leaky error.
+    mockPrisma.decision.findMany.mockRejectedValue(
+      new Error('connection to db at 10.0.0.1:5432 timed out — internal stack info')
+    );
+
+    mockPrisma.complianceReport.update.mockResolvedValue({
+      ...jobRow,
+      status: 'failed',
+      errorCode: 'generation_failed',
+      errorMessage: 'connection to db at 10.0.0.1:5432 timed out — internal stack info',
     });
+
+    const result = await processComplianceReportJob('rpt_err');
+
+    expect(result.status).toBe('failed');
+    expect(mockPrisma.complianceReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'rpt_err' },
+        data: expect.objectContaining({
+          status: 'failed',
+          errorCode: 'generation_failed',
+          // Raw message is persisted server-side for ops, but never leaked
+          // to the client (see buildComplianceReportStatus).
+          errorMessage: expect.stringContaining('timed out'),
+        }),
+      })
+    );
+  });
+
+  it('processComplianceReportJob reclaims stale processing rows older than the watchdog window', async () => {
+    const jobRow = baseRow({ id: 'rpt_zombie', status: 'processing' });
+    mockPrisma.complianceReport.findUnique.mockResolvedValue(jobRow);
+    mockPrisma.complianceReport.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.complianceReport.update.mockResolvedValue({ ...jobRow, status: 'ready' });
+
+    mockPrisma.decision.findMany.mockResolvedValue([]);
+    mockPrisma.contextMemory.findMany.mockResolvedValue([]);
+    mockPrisma.budgetAlert.findMany.mockResolvedValue([]);
+    mockPrisma.budgetLimit.findMany.mockResolvedValue([]);
+    mockPrisma.usageRecord.findMany.mockResolvedValue([]);
+    mockPrisma.purchaseRecord.findMany.mockResolvedValue([]);
+    mockPrisma.orgMembership.findMany.mockResolvedValue([]);
+    mockPrisma.verificationToken.count.mockResolvedValue(0);
+
+    const before = Date.now();
+    await processComplianceReportJob('rpt_zombie');
+    const after = Date.now();
+
+    const call = mockPrisma.complianceReport.updateMany.mock.calls[0][0];
+    const reclaimClause = call.where.OR.find(
+      (clause: { status?: string }) => clause.status === 'processing'
+    );
+    expect(reclaimClause).toBeDefined();
+    const cutoff = (reclaimClause.updatedAt as { lt: Date }).lt.getTime();
+    expect(cutoff).toBeGreaterThanOrEqual(before - STALE_PROCESSING_MS - 50);
+    expect(cutoff).toBeLessThanOrEqual(after - STALE_PROCESSING_MS + 50);
+  });
+
+  it('publishes status payloads with artifact URLs once the report is ready', () => {
+    const payload = buildComplianceReportStatus(
+      baseRow({
+        id: 'rpt_ready',
+        status: 'ready',
+        startTime: new Date('2026-04-01T00:00:00.000Z'),
+        endTime: new Date('2026-04-24T00:00:00.000Z'),
+        generatedAt: new Date('2026-04-24T15:00:00.000Z'),
+        completedAt: new Date('2026-04-24T15:00:01.000Z'),
+        pdfData: Buffer.from('%PDF-1.4'),
+        createdAt: new Date('2026-04-24T14:59:00.000Z'),
+        updatedAt: new Date('2026-04-24T15:00:01.000Z'),
+      }) as any
+    );
 
     expect(payload.report_id).toBe('rpt_ready');
     expect(payload.status).toBe('ready');
+    expect(payload.error_code).toBeNull();
     expect(payload.download_url).toBe('/api/v1/reports/rpt_ready?download=1&format=pdf');
     expect(payload.artifacts).toEqual({
       pdf: '/api/v1/reports/rpt_ready?download=1&format=pdf',
       json: '/api/v1/reports/rpt_ready?download=1&format=json',
     });
+  });
+
+  it('failed reports return a sanitized error_code and never leak the raw error_message', () => {
+    const payload = buildComplianceReportStatus(
+      baseRow({
+        id: 'rpt_failed',
+        status: 'failed',
+        errorCode: 'generation_failed',
+        errorMessage: 'connection to db at 10.0.0.1:5432 timed out — internal stack info',
+      }) as any
+    );
+
+    expect(payload.status).toBe('failed');
+    expect(payload.error_code).toBe('generation_failed');
+    expect(JSON.stringify(payload)).not.toContain('10.0.0.1');
+    expect(JSON.stringify(payload)).not.toContain('timed out');
+    expect((payload as any).error).toBeUndefined();
+  });
+
+  it('failed reports without a stored error_code still surface a stable enum value', () => {
+    const payload = buildComplianceReportStatus(
+      baseRow({
+        id: 'rpt_legacy_failed',
+        status: 'failed',
+        errorCode: null,
+        errorMessage: 'something exploded',
+      }) as any
+    );
+
+    expect(payload.status).toBe('failed');
+    expect(payload.error_code).toBe('generation_failed');
   });
 });

--- a/apps/platform/__tests__/lib/compliance-report-storage.test.ts
+++ b/apps/platform/__tests__/lib/compliance-report-storage.test.ts
@@ -1,0 +1,143 @@
+import { randomBytes } from 'crypto';
+
+import { put as mockPut } from '@vercel/blob';
+
+import * as storage from '@/lib/services/compliance-report-storage';
+
+const KEY_HEX = randomBytes(32).toString('hex');
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
+  process.env.COMPLIANCE_REPORT_ENCRYPTION_KEY = KEY_HEX;
+  (mockPut as jest.Mock).mockClear();
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('compliance-report-storage encryption-at-rest', () => {
+  it('uploads ciphertext to blob — plaintext PDF bytes never appear in the upload payload', async () => {
+    const plaintext = Buffer.from('%PDF-1.4 secret-pii-marker\nemail=victim@example.com\n%%EOF');
+    let uploadedPayload: Buffer | undefined;
+    (mockPut as jest.Mock).mockImplementationOnce(async (pathname: string, body: Buffer) => {
+      uploadedPayload = Buffer.from(body);
+      return {
+        url: `https://blob.test.local/${pathname}-suffix`,
+        pathname: `${pathname}-suffix`,
+        contentType: 'application/octet-stream',
+        contentDisposition: 'inline',
+        downloadUrl: `https://blob.test.local/${pathname}-suffix?download=1`,
+      };
+    });
+
+    const stored = await storage.storeReportPdf({
+      reportId: 'rpt_1',
+      orgId: 'org-1',
+      pdf: plaintext,
+    });
+
+    expect(stored).toEqual({
+      url: expect.stringMatching(/blob\.test\.local/),
+      pathname: expect.stringContaining('compliance-reports/org-1/rpt_1.pdf'),
+    });
+    expect(uploadedPayload).toBeDefined();
+    expect(uploadedPayload!.includes('secret-pii-marker')).toBe(false);
+    expect(uploadedPayload!.includes('victim@example.com')).toBe(false);
+    expect(uploadedPayload!.subarray(0, 8).toString('utf8')).toBe('GACPDF1\0');
+  });
+
+  it('round-trips through the encrypt/decrypt envelope', async () => {
+    const plaintext = Buffer.from('compliance-report-pdf-bytes');
+    const encrypted = storage.__internal.encryptPdf(plaintext, Buffer.from(KEY_HEX, 'hex'));
+    const decrypted = storage.__internal.decryptPdf(encrypted, Buffer.from(KEY_HEX, 'hex'));
+    expect(decrypted.equals(plaintext)).toBe(true);
+  });
+
+  it('rejects payloads that were not encrypted by this service (missing magic header)', async () => {
+    const fake = Buffer.concat([Buffer.from('NOTOURS!', 'utf8'), Buffer.alloc(40, 0)]);
+    expect(() => storage.__internal.decryptPdf(fake, Buffer.from(KEY_HEX, 'hex'))).toThrow(
+      /magic header/i,
+    );
+  });
+
+  it('rejects ciphertext whose authentication tag fails (tamper or wrong key)', async () => {
+    const plaintext = Buffer.from('compliance-report-pdf-bytes');
+    const encrypted = storage.__internal.encryptPdf(plaintext, Buffer.from(KEY_HEX, 'hex'));
+    // flip a byte inside the ciphertext region to trigger GCM auth failure
+    encrypted[encrypted.length - 1] ^= 0xff;
+    expect(() => storage.__internal.decryptPdf(encrypted, Buffer.from(KEY_HEX, 'hex'))).toThrow();
+
+    const wrongKey = randomBytes(32);
+    const fresh = storage.__internal.encryptPdf(plaintext, Buffer.from(KEY_HEX, 'hex'));
+    expect(() => storage.__internal.decryptPdf(fresh, wrongKey)).toThrow();
+  });
+
+  it('refuses to store a PDF when the encryption key is missing', async () => {
+    delete process.env.COMPLIANCE_REPORT_ENCRYPTION_KEY;
+    await expect(
+      storage.storeReportPdf({ reportId: 'rpt_x', orgId: 'org-1', pdf: Buffer.from('a') }),
+    ).rejects.toThrow(/COMPLIANCE_REPORT_ENCRYPTION_KEY/);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('refuses to store a PDF when the encryption key is the wrong length', async () => {
+    process.env.COMPLIANCE_REPORT_ENCRYPTION_KEY = 'deadbeef'; // 4 bytes
+    await expect(
+      storage.storeReportPdf({ reportId: 'rpt_x', orgId: 'org-1', pdf: Buffer.from('a') }),
+    ).rejects.toThrow(/64-character hex/);
+  });
+
+  it('skips upload entirely when blob storage is not configured', async () => {
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const result = await storage.storeReportPdf({
+      reportId: 'rpt_x',
+      orgId: 'org-1',
+      pdf: Buffer.from('a'),
+    });
+    expect(result).toBeNull();
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('fetchReportPdfBytes decrypts what storeReportPdf wrote', async () => {
+    const plaintext = Buffer.from('%PDF-1.4 round-trip-content\n%%EOF');
+    let uploaded: Buffer | undefined;
+    (mockPut as jest.Mock).mockImplementationOnce(async (pathname: string, body: Buffer) => {
+      uploaded = Buffer.from(body);
+      return {
+        url: `https://blob.test.local/${pathname}-suffix`,
+        pathname: `${pathname}-suffix`,
+        contentType: 'application/octet-stream',
+        contentDisposition: 'inline',
+        downloadUrl: `https://blob.test.local/${pathname}-suffix?download=1`,
+      };
+    });
+
+    const stored = await storage.storeReportPdf({
+      reportId: 'rpt_round',
+      orgId: 'org-1',
+      pdf: plaintext,
+    });
+    expect(stored).not.toBeNull();
+    expect(uploaded).toBeDefined();
+
+    const originalFetch = global.fetch;
+    (global as any).fetch = jest.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () =>
+        uploaded!.buffer.slice(
+          uploaded!.byteOffset,
+          uploaded!.byteOffset + uploaded!.byteLength,
+        ),
+    }));
+
+    try {
+      const decrypted = await storage.fetchReportPdfBytes(stored!.url);
+      expect(decrypted.equals(plaintext)).toBe(true);
+    } finally {
+      (global as any).fetch = originalFetch;
+    }
+  });
+});

--- a/apps/platform/app/api/v1/reports/[id]/route.ts
+++ b/apps/platform/app/api/v1/reports/[id]/route.ts
@@ -67,8 +67,10 @@ export async function GET(
       );
     }
 
-    const asset = getComplianceReportDownload(report, format);
+    const asset = await getComplianceReportDownload(report, format);
 
+    // orgId is intentionally on the audit log so PII-bearing report downloads
+    // remain tenant-scoped through retention/legal-hold review queries.
     await prisma.auditLog.create({
       data: {
         userId: auth.userId,
@@ -78,6 +80,8 @@ export async function GET(
         details: {
           reportId: report.id,
           format,
+          containsPii: report.containsPii,
+          storage: report.pdfBlobUrl ? 'blob' : 'inline',
         },
       },
     });

--- a/apps/platform/jest.config.js
+++ b/apps/platform/jest.config.js
@@ -12,6 +12,8 @@ const config = {
     '^@governs-ai/(.*)$': '<rootDir>/__mocks__/governs-ai/$1.ts',
     // server-only throws in Node/Jest context — stub it out
     '^server-only$': '<rootDir>/__mocks__/server-only.js',
+    // @vercel/blob hits the network at runtime; tests use a stub
+    '^@vercel/blob$': '<rootDir>/__mocks__/vercel-blob.ts',
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {

--- a/apps/platform/lib/services/compliance-report-service.ts
+++ b/apps/platform/lib/services/compliance-report-service.ts
@@ -1,4 +1,8 @@
 import { prisma, type Prisma } from '@governs-ai/db';
+import {
+  fetchReportPdfBytes,
+  storeReportPdf,
+} from './compliance-report-storage';
 
 type PrismaTxClient = Prisma.TransactionClient;
 type PrismaWriteClient = typeof prisma | PrismaTxClient;
@@ -6,6 +10,11 @@ type PrismaWriteClient = typeof prisma | PrismaTxClient;
 export type ComplianceReportStatus = 'pending' | 'processing' | 'ready' | 'failed';
 export type ComplianceReportSource = 'on_demand' | 'scheduled';
 export type ComplianceReportFormat = 'pdf' | 'json';
+export type ComplianceReportErrorCode = 'generation_failed';
+
+// Window after which a `processing` row is considered abandoned (worker died
+// between claim and the final `ready`/`failed` write) and can be re-claimed.
+export const STALE_PROCESSING_MS = 15 * 60 * 1000;
 
 export interface ComplianceReportJobInput {
   orgId: string;
@@ -27,8 +36,12 @@ export interface ComplianceReportJobRecord {
   generatedAt: Date | null;
   completedAt: Date | null;
   errorMessage: string | null;
+  errorCode: string | null;
   reportJson: ComplianceSummaryReport | null;
   pdfData: Buffer | null;
+  pdfBlobUrl: string | null;
+  pdfBlobPath: string | null;
+  containsPii: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -121,7 +134,7 @@ export interface ComplianceReportStatusResponse {
   generated_at: string | null;
   created_at: string;
   updated_at: string;
-  error: string | null;
+  error_code: ComplianceReportErrorCode | null;
   download_url: string | null;
   artifacts: {
     pdf: string | null;
@@ -417,21 +430,30 @@ export async function processComplianceReportJob(
   if (
     existing.status === 'ready' &&
     existing.reportJson &&
-    existing.pdfData
+    (existing.pdfBlobUrl || existing.pdfData)
   ) {
     return existing;
   }
 
-  // Atomic claim: only the call that flips pending|failed -> processing proceeds.
+  // Atomic claim. We accept three cases:
+  //   1. status = pending           — fresh job
+  //   2. status = failed            — retry of a previously failed job
+  //   3. status = processing AND updatedAt < now-15min — reclaim of a zombie
+  //      (worker died between claim and the final ready/failed write)
   // Concurrent callers see count === 0 and short-circuit to the existing row.
+  const staleProcessingCutoff = new Date(Date.now() - STALE_PROCESSING_MS);
   const claim = await prisma.complianceReport.updateMany({
     where: {
       id: reportId,
-      status: { in: ['pending', 'failed'] },
+      OR: [
+        { status: { in: ['pending', 'failed'] } },
+        { status: 'processing', updatedAt: { lt: staleProcessingCutoff } },
+      ],
     },
     data: {
       status: 'processing',
       errorMessage: null,
+      errorCode: null,
     },
   });
 
@@ -450,6 +472,29 @@ export async function processComplianceReportJob(
     });
 
     const pdfData = complianceReportToPdf(reportJson);
+
+    let pdfBlobUrl: string | null = null;
+    let pdfBlobPath: string | null = null;
+    let pdfDataForRow: Buffer | null = pdfData;
+
+    try {
+      const stored = await storeReportPdf({
+        reportId: existing.id,
+        orgId: existing.orgId,
+        pdf: pdfData,
+      });
+      if (stored) {
+        pdfBlobUrl = stored.url;
+        pdfBlobPath = stored.pathname;
+        // Keep PDF bytes out of Postgres once the blob copy is durable.
+        pdfDataForRow = null;
+      }
+    } catch (error) {
+      // Blob upload failed — fall back to inline pdfData so generation still
+      // succeeds. Surfaced via server logs only; the row itself is unaffected.
+      console.error('Compliance report blob upload failed:', error);
+    }
+
     const updated = await prisma.complianceReport.update({
       where: { id: reportId },
       data: {
@@ -457,20 +502,27 @@ export async function processComplianceReportJob(
         generatedAt: new Date(reportJson.generatedAt),
         completedAt: new Date(),
         errorMessage: null,
+        errorCode: null,
         reportJson: reportJson as unknown as Prisma.InputJsonValue,
-        pdfData,
+        pdfData: pdfDataForRow,
+        pdfBlobUrl,
+        pdfBlobPath,
+        containsPii: true,
       },
     });
 
     return updated as unknown as ComplianceReportJobRecord;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    console.error('Compliance report generation failed:', error);
+    // Raw error_message stays in Postgres + Sentry/console for ops; the public
+    // status response only ever exposes the sanitized error_code enum.
+    console.error('Compliance report generation failed:', { reportId, error });
     const failed = await prisma.complianceReport.update({
       where: { id: reportId },
       data: {
         status: 'failed',
         errorMessage: message,
+        errorCode: 'generation_failed',
         completedAt: new Date(),
       },
     });
@@ -493,7 +545,14 @@ export async function ensureComplianceReportJobReady(
   }
 
   if (existing.status === 'processing') {
-    // Another worker holds the claim; let the caller poll again.
+    // If the row has been stuck in processing past the watchdog window the
+    // worker probably died. Try a self-heal claim — `processComplianceReportJob`
+    // will reclaim if stale, otherwise its claim returns count=0 and we get
+    // the row back unchanged.
+    const stale = existing.updatedAt.getTime() < Date.now() - STALE_PROCESSING_MS;
+    if (stale) {
+      return processComplianceReportJob(reportId);
+    }
     return existing;
   }
 
@@ -502,6 +561,10 @@ export async function ensureComplianceReportJobReady(
   }
 
   return processComplianceReportJob(reportId);
+}
+
+function sanitizeErrorCode(value: string | null): ComplianceReportErrorCode | null {
+  return value === 'generation_failed' ? 'generation_failed' : null;
 }
 
 export function buildComplianceReportStatus(
@@ -521,20 +584,25 @@ export function buildComplianceReportStatus(
     generated_at: toIso(report.generatedAt),
     created_at: report.createdAt.toISOString(),
     updated_at: report.updatedAt.toISOString(),
-    error: report.errorMessage,
+    // The raw errorMessage may include stack trace details, internal IDs, or
+    // SQL error text; never return it on the public status path. Surface a
+    // stable enum instead — the raw message is logged server-side.
+    error_code: report.status === 'failed'
+      ? sanitizeErrorCode(report.errorCode) ?? 'generation_failed'
+      : null,
     download_url: artifacts.pdf,
     artifacts,
   };
 }
 
-export function getComplianceReportDownload(
+export async function getComplianceReportDownload(
   report: ComplianceReportJobRecord,
   format: ComplianceReportFormat
-): {
+): Promise<{
   body: Buffer | string;
   contentType: string;
   filename: string;
-} {
+}> {
   if (report.status !== 'ready') {
     throw new Error('Report is not ready for download');
   }
@@ -553,12 +621,21 @@ export function getComplianceReportDownload(
     };
   }
 
-  if (!report.pdfData) {
+  // PDF: prefer blob storage, fall back to legacy inline bytes for rows that
+  // pre-date the blob migration.
+  let pdfBytes: Buffer | null = null;
+  if (report.pdfBlobUrl) {
+    pdfBytes = await fetchReportPdfBytes(report.pdfBlobUrl);
+  } else if (report.pdfData) {
+    pdfBytes = report.pdfData;
+  }
+
+  if (!pdfBytes) {
     throw new Error('PDF artifact is missing');
   }
 
   return {
-    body: report.pdfData,
+    body: pdfBytes,
     contentType: 'application/pdf',
     filename: `compliance-report-${report.orgId}-${safeTimestamp}.pdf`,
   };

--- a/apps/platform/lib/services/compliance-report-storage.ts
+++ b/apps/platform/lib/services/compliance-report-storage.ts
@@ -1,0 +1,59 @@
+import { put, del, type PutBlobResult } from '@vercel/blob';
+
+export interface StoredReportPdf {
+  url: string;
+  pathname: string;
+}
+
+interface StoreOptions {
+  reportId: string;
+  orgId: string;
+  pdf: Buffer;
+}
+
+const BLOB_TOKEN_ENV = 'BLOB_READ_WRITE_TOKEN';
+
+function blobConfigured(): boolean {
+  return Boolean(process.env[BLOB_TOKEN_ENV]);
+}
+
+export function isBlobStorageConfigured(): boolean {
+  return blobConfigured();
+}
+
+export function buildReportBlobPath(orgId: string, reportId: string): string {
+  // Path scoped by org so accidental cross-tenant globs are impossible.
+  return `compliance-reports/${orgId}/${reportId}.pdf`;
+}
+
+export async function storeReportPdf(options: StoreOptions): Promise<StoredReportPdf | null> {
+  if (!blobConfigured()) {
+    return null;
+  }
+
+  const pathname = buildReportBlobPath(options.orgId, options.reportId);
+  const result: PutBlobResult = await put(pathname, options.pdf, {
+    access: 'public',
+    addRandomSuffix: true,
+    contentType: 'application/pdf',
+    cacheControlMaxAge: 0,
+  });
+
+  return { url: result.url, pathname: result.pathname };
+}
+
+export async function deleteReportPdf(pathnameOrUrl: string): Promise<void> {
+  if (!blobConfigured()) {
+    return;
+  }
+  await del(pathnameOrUrl);
+}
+
+export async function fetchReportPdfBytes(blobUrl: string): Promise<Buffer> {
+  const response = await fetch(blobUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch report PDF from blob (${response.status})`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}

--- a/apps/platform/lib/services/compliance-report-storage.ts
+++ b/apps/platform/lib/services/compliance-report-storage.ts
@@ -1,4 +1,5 @@
 import { put, del, type PutBlobResult } from '@vercel/blob';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 
 export interface StoredReportPdf {
   url: string;
@@ -12,9 +13,62 @@ interface StoreOptions {
 }
 
 const BLOB_TOKEN_ENV = 'BLOB_READ_WRITE_TOKEN';
+const ENCRYPTION_KEY_ENV = 'COMPLIANCE_REPORT_ENCRYPTION_KEY';
+
+// Wire format for an encrypted PDF blob. The blob is treated as opaque
+// ciphertext: even though Vercel Blob serves the URL publicly, the bytes
+// behind that URL cannot be decrypted without the platform-held key, so a
+// URL leak alone does not disclose PII. The leading magic + version let
+// future migrations (e.g. KMS-backed keys, per-org subkeys) detect old
+// blobs and decrypt them with the right path.
+const MAGIC = Buffer.from('GACPDF1\0', 'utf8'); // 8 bytes: GovernsAI Compliance PDF v1
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+const HEADER_LENGTH = MAGIC.length + IV_LENGTH + TAG_LENGTH;
 
 function blobConfigured(): boolean {
   return Boolean(process.env[BLOB_TOKEN_ENV]);
+}
+
+function readEncryptionKey(): Buffer {
+  const raw = process.env[ENCRYPTION_KEY_ENV];
+  if (!raw) {
+    throw new Error(
+      `${ENCRYPTION_KEY_ENV} is required when ${BLOB_TOKEN_ENV} is set. Generate ` +
+        "a 32-byte key with `openssl rand -hex 32` and configure it per environment.",
+    );
+  }
+  const key = Buffer.from(raw, 'hex');
+  if (key.length !== 32) {
+    throw new Error(
+      `${ENCRYPTION_KEY_ENV} must be a 64-character hex string (32 bytes); got ${key.length} bytes.`,
+    );
+  }
+  return key;
+}
+
+function encryptPdf(pdf: Buffer, key: Buffer): Buffer {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(pdf), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([MAGIC, iv, tag, ciphertext]);
+}
+
+function decryptPdf(payload: Buffer, key: Buffer): Buffer {
+  if (payload.length < HEADER_LENGTH) {
+    throw new Error('encrypted PDF payload truncated');
+  }
+  const magic = payload.subarray(0, MAGIC.length);
+  if (!magic.equals(MAGIC)) {
+    throw new Error('encrypted PDF magic header missing or unrecognized');
+  }
+  const iv = payload.subarray(MAGIC.length, MAGIC.length + IV_LENGTH);
+  const tag = payload.subarray(MAGIC.length + IV_LENGTH, HEADER_LENGTH);
+  const ciphertext = payload.subarray(HEADER_LENGTH);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
 
 export function isBlobStorageConfigured(): boolean {
@@ -31,11 +85,15 @@ export async function storeReportPdf(options: StoreOptions): Promise<StoredRepor
     return null;
   }
 
+  const key = readEncryptionKey();
+  const encrypted = encryptPdf(options.pdf, key);
   const pathname = buildReportBlobPath(options.orgId, options.reportId);
-  const result: PutBlobResult = await put(pathname, options.pdf, {
+  // Blob remains publicly addressable — the encrypted payload is the security
+  // boundary. The admin-gated /api/v1/reports/:id route fetches and decrypts.
+  const result: PutBlobResult = await put(pathname, encrypted, {
     access: 'public',
     addRandomSuffix: true,
-    contentType: 'application/pdf',
+    contentType: 'application/octet-stream',
     cacheControlMaxAge: 0,
   });
 
@@ -55,5 +113,16 @@ export async function fetchReportPdfBytes(blobUrl: string): Promise<Buffer> {
     throw new Error(`Failed to fetch report PDF from blob (${response.status})`);
   }
   const arrayBuffer = await response.arrayBuffer();
-  return Buffer.from(arrayBuffer);
+  const payload = Buffer.from(arrayBuffer);
+  const key = readEncryptionKey();
+  return decryptPdf(payload, key);
 }
+
+// Internal — exported only so unit tests can pin the encryption envelope and
+// verify that ciphertext at rest does not contain plaintext bytes.
+export const __internal = {
+  encryptPdf,
+  decryptPdf,
+  HEADER_LENGTH,
+  MAGIC,
+};

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-slot": "1.1.1",
     "@simplewebauthn/browser": "^13.2.0",
     "@simplewebauthn/server": "^13.2.1",
+    "@vercel/blob": "^0.27.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/mime-types": "^3.0.1",
     "@types/multer": "^2.0.0",

--- a/apps/platform/scripts/backfill-compliance-report-blobs.ts
+++ b/apps/platform/scripts/backfill-compliance-report-blobs.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env -S node --import tsx
+/**
+ * GOV-1885 — Backfill compliance report PDFs into Vercel Blob.
+ *
+ * Walks every ComplianceReport row that has inline `pdfData` but no
+ * `pdfBlobUrl`, uploads the PDF bytes to Vercel Blob, persists the URL/path on
+ * the row, then nulls out `pdfData`. Resumable: re-runs skip rows that already
+ * have a blob URL.
+ *
+ * Requires:
+ *   DATABASE_URL              — production Postgres
+ *   BLOB_READ_WRITE_TOKEN     — Vercel Blob write token
+ *
+ * Usage:
+ *   pnpm --filter @governs-ai/platform exec tsx \
+ *     apps/platform/scripts/backfill-compliance-report-blobs.ts [--dry-run] [--batch=50]
+ */
+
+import { prisma } from '@governs-ai/db';
+import {
+  isBlobStorageConfigured,
+  storeReportPdf,
+} from '@/lib/services/compliance-report-storage';
+
+interface CliFlags {
+  dryRun: boolean;
+  batchSize: number;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = { dryRun: false, batchSize: 50 };
+  for (const arg of argv) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg.startsWith('--batch=')) flags.batchSize = Number(arg.split('=')[1]) || 50;
+  }
+  return flags;
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+
+  if (!isBlobStorageConfigured()) {
+    console.error('BLOB_READ_WRITE_TOKEN is not set. Aborting.');
+    process.exit(1);
+  }
+
+  console.log(
+    `Backfill starting (dryRun=${flags.dryRun} batchSize=${flags.batchSize})`
+  );
+
+  let totalScanned = 0;
+  let totalUploaded = 0;
+  let totalSkipped = 0;
+  let totalFailed = 0;
+  let cursor: string | null = null;
+
+  for (;;) {
+    const rows = await prisma.complianceReport.findMany({
+      where: {
+        status: 'ready',
+        pdfBlobUrl: null,
+        pdfData: { not: null },
+        ...(cursor ? { id: { gt: cursor } } : {}),
+      },
+      orderBy: { id: 'asc' },
+      take: flags.batchSize,
+      select: { id: true, orgId: true, pdfData: true },
+    });
+
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      totalScanned += 1;
+      cursor = row.id;
+
+      if (!row.pdfData) {
+        totalSkipped += 1;
+        continue;
+      }
+
+      if (flags.dryRun) {
+        console.log(`[dry-run] would upload ${row.id} (org=${row.orgId})`);
+        continue;
+      }
+
+      try {
+        const stored = await storeReportPdf({
+          reportId: row.id,
+          orgId: row.orgId,
+          pdf: Buffer.from(row.pdfData),
+        });
+
+        if (!stored) {
+          totalFailed += 1;
+          console.error(`upload returned null for ${row.id}`);
+          continue;
+        }
+
+        await prisma.complianceReport.update({
+          where: { id: row.id },
+          data: {
+            pdfBlobUrl: stored.url,
+            pdfBlobPath: stored.pathname,
+            pdfData: null,
+            containsPii: true,
+          },
+        });
+
+        totalUploaded += 1;
+        console.log(`uploaded ${row.id} -> ${stored.pathname}`);
+      } catch (error) {
+        totalFailed += 1;
+        console.error(`failed ${row.id}:`, error);
+      }
+    }
+  }
+
+  console.log(
+    `Backfill done: scanned=${totalScanned} uploaded=${totalUploaded} skipped=${totalSkipped} failed=${totalFailed}`
+  );
+
+  if (totalFailed > 0) {
+    process.exit(2);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Backfill crashed:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/migrations/20260424180000_compliance_report_hardening/migration.sql
+++ b/packages/db/migrations/20260424180000_compliance_report_hardening/migration.sql
@@ -1,0 +1,26 @@
+-- GOV-1885: compliance report hardening
+--   * error_code: stable enum surfaced to clients (raw error_message stays internal)
+--   * pdf_blob_url / pdf_blob_path: artifact storage outside Postgres (Vercel Blob)
+--   * contains_pii: explicit retention/legal-hold signal — reports persist member emails
+--   * (status, updated_at) index supports stale `processing` reclaim watchdog
+
+ALTER TABLE "compliance_reports"
+  ADD COLUMN "error_code" TEXT,
+  ADD COLUMN "pdf_blob_url" TEXT,
+  ADD COLUMN "pdf_blob_path" TEXT,
+  ADD COLUMN "contains_pii" BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON TABLE  "compliance_reports" IS
+  'Compliance summary reports. Rows persist member emails and decision reasons that may include PII signals — treat as PII-bearing for retention and legal-hold logic. See contains_pii.';
+
+COMMENT ON COLUMN "compliance_reports"."contains_pii" IS
+  'True when the row contains PII (member roster, decision reasons). Defaults to true; flip to false only after a deliberate scrub.';
+
+COMMENT ON COLUMN "compliance_reports"."error_code" IS
+  'Stable, client-safe error enum (e.g. generation_failed). The raw error_message is for server-side observability only and must not be returned by the public API.';
+
+COMMENT ON COLUMN "compliance_reports"."pdf_blob_url" IS
+  'Vercel Blob URL for the rendered PDF. When present, downloads stream from blob and pdf_data may be null.';
+
+CREATE INDEX "compliance_reports_status_updated_at_idx"
+  ON "compliance_reports"("status", "updated_at");

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -392,8 +392,12 @@ model ComplianceReport {
   generatedAt   DateTime? @map("generated_at")
   completedAt   DateTime? @map("completed_at")
   errorMessage  String?   @map("error_message")
+  errorCode     String?   @map("error_code")
   reportJson    Json?     @map("report_json")
   pdfData       Bytes?    @map("pdf_data")
+  pdfBlobUrl    String?   @map("pdf_blob_url")
+  pdfBlobPath   String?   @map("pdf_blob_path")
+  containsPii   Boolean   @default(true) @map("contains_pii")
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
   org           Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
@@ -401,6 +405,7 @@ model ComplianceReport {
 
   @@index([orgId, createdAt(sort: Desc)])
   @@index([status, createdAt(sort: Desc)])
+  @@index([status, updatedAt])
   @@index([requestedById, createdAt(sort: Desc)])
   @@map("compliance_reports")
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@types/speakeasy':
         specifier: ^2.0.10
         version: 2.0.10
+      '@vercel/blob':
+        specifier: ^0.27.0
+        version: 0.27.3
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
@@ -936,6 +939,10 @@ packages:
   '@eslint/plugin-kit@0.3.4':
     resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@floating-ui/core@1.7.2':
     resolution: {integrity: sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==}
@@ -2424,6 +2431,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/blob@0.27.3':
+    resolution: {integrity: sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==}
+    engines: {node: '>=16.14'}
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
@@ -2537,6 +2548,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3492,6 +3506,10 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -3539,6 +3557,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -4620,6 +4641,10 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4935,6 +4960,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -5117,6 +5146,10 @@ packages:
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -5675,6 +5708,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.1
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.2':
     dependencies:
@@ -7302,6 +7337,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/blob@0.27.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 5.29.0
+
   '@xmldom/xmldom@0.8.11': {}
 
   accepts@1.3.8:
@@ -7438,6 +7481,10 @@ snapshots:
       tslib: 2.8.1
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -8679,6 +8726,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
@@ -8720,6 +8769,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -9997,6 +10048,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rimraf@3.0.2:
@@ -10410,6 +10463,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  throttleit@2.1.0: {}
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -10578,6 +10633,10 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.8.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Bundles the deferred items from [PR #44](https://github.com/Governs-AI/governsai-console/pull/44) (Cipher mediums 5–7, Nexus non-blocker 8, decision on 9). None of these block production; this lands them ahead of broader rollout / GA.

### What changed

- **(5) Sanitize `errorMessage` on the public status path.** New `error_code` enum (`generation_failed`); raw `errorMessage` stays in Postgres + console logs for ops only. `buildComplianceReportStatus` returns `error_code` instead of `error`, and never echoes the row's stored message.
- **(6) Persist rendered PDFs to Vercel Blob.** New `@vercel/blob` dependency. PDFs are uploaded to `compliance-reports/<orgId>/<reportId>.pdf` with `addRandomSuffix: true`. `pdf_blob_url` / `pdf_blob_path` columns store the location; `pdf_data` remains as a fallback for dev/test environments without `BLOB_READ_WRITE_TOKEN` and for legacy rows pre-migration. Downloads still flow through the admin-gated route so the audit log + auth stay authoritative. Backfill: `apps/platform/scripts/backfill-compliance-report-blobs.ts` (resumable).
- **(7) `contains_pii` flag (default `true`) on `compliance_reports`.** Plus table/column comments documenting the PII retention contract. `compliance.report.download` audit log entries now include `containsPii` and `storage` (`blob` | `inline`).
- **(8) Stale `processing` reclaim.** The atomic claim now also matches `status='processing' AND updated_at < now() - 15 min`, so a worker that died between claim and the final write doesn't lock the row forever. `ensureComplianceReportJobReady` self-heals stale rows on the next status GET, so a dedicated watchdog cron is not required.
- **(9) TOCTOU on `count → create`** is recorded as a deliberate won't-fix at admin-only / cap = 3 (worst case is briefly `cap + concurrent_admins`). README documents the upgrade path (partial unique index or `RAISE`-on-cap CTE) for when the cap is raised.

### Schema

Migration: `packages/db/migrations/20260424180000_compliance_report_hardening`

```
ALTER TABLE compliance_reports
  ADD COLUMN error_code TEXT,
  ADD COLUMN pdf_blob_url TEXT,
  ADD COLUMN pdf_blob_path TEXT,
  ADD COLUMN contains_pii BOOLEAN NOT NULL DEFAULT true;
CREATE INDEX compliance_reports_status_updated_at_idx
  ON compliance_reports(status, updated_at);
```

### API contract change (non-breaking add, breaking remove)

The status payload now returns `error_code` instead of `error`. Quill currently keys off `status === 'failed'` in its UI, but if any consumer reads `error`, they should switch to `error_code`. Documented in `apps/platform/README.md`.

## GovernsAI Tracker issue

GOV-1885

## Reviewers

Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan

- [ ] `pnpm --filter @governs-ai/platform run test` (jest) — new cases cover sanitized error code, blob upload happy path, blob fallback, stale reclaim window, and audit log fields.
- [ ] `pnpm run generate` regenerates Prisma client cleanly with the new fields.
- [ ] Local stack: generate a report with `BLOB_READ_WRITE_TOKEN` set, confirm `pdf_data` is null on the row and download still works.
- [ ] Local stack: generate a report without the token, confirm fallback path keeps inline `pdf_data`.
- [ ] Force a generation failure (e.g. transient DB error during `buildComplianceReport`) and confirm the public status response only shows `error_code: 'generation_failed'`.
- [ ] Run the backfill script in dry-run mode against a staging DB before production.