### PR TITLE
feat(platform): audit log CSV export endpoint (GOV-602)

### DIFF
--- a/apps/platform/__tests__/api/audit-export.test.ts
+++ b/apps/platform/__tests__/api/audit-export.test.ts
@@ -149,6 +149,117 @@ describe('GET /api/v1/audit/export — CSV output format', () => {
     );
   });
 
+  it.each([
+    ['equals', '=cmd|"/c calc"!A1'],
+    ['plus', '+1+1'],
+    ['minus', '-2+3'],
+    ['at', '@SUM(A1:A2)'],
+    ['tab', '\t=cmd'],
+  ])(
+    'defuses spreadsheet formula leads (CWE-1236) — %s prefix',
+    async (_label, payload) => {
+      mockPrisma.decision.findMany.mockResolvedValueOnce([
+        {
+          id: 'dec-1',
+          ts: new Date('2026-03-01T00:00:00.000Z'),
+          orgId: 'org-1',
+          decision: 'allow',
+          direction: 'ingress',
+          tool: payload,
+          scope: payload,
+          policyId: null,
+          correlationId: payload,
+          latencyMs: null,
+          payloadHash: 'h',
+          reasons: null,
+          tags: [],
+          detectorSummary: {},
+        },
+      ]);
+
+      const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+      const body = await readStream(res);
+      const lines = body.trim().split('\n');
+      expect(lines).toHaveLength(2);
+
+      // Every formula-leading column must start with a literal tab so
+      // spreadsheet engines treat it as text, never a formula.
+      const cells = lines[1].split(',');
+      // tool is column index 5, scope is 6, correlationId is 8
+      const formulaCells = [cells[5], cells[6], cells[8]];
+      for (const raw of formulaCells) {
+        // Strip RFC 4180 outer quoting if present, then assert leading \t.
+        const unquoted =
+          raw.startsWith('"') && raw.endsWith('"')
+            ? raw.slice(1, -1).replace(/""/g, '"')
+            : raw;
+        expect(unquoted.startsWith('\t')).toBe(true);
+        // The original formula content is preserved verbatim after the tab.
+        expect(unquoted).toBe(`\t${payload}`);
+      }
+    },
+  );
+
+  it('defuses formula leads inside JSON-serialized columns (reasons/tags)', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce([
+      {
+        id: 'dec-1',
+        ts: new Date('2026-03-01T00:00:00.000Z'),
+        orgId: 'org-1',
+        decision: 'allow',
+        direction: 'ingress',
+        tool: 't',
+        scope: 's',
+        policyId: 'p',
+        correlationId: 'c',
+        latencyMs: 0,
+        payloadHash: 'h',
+        // JSON.stringify of a string starts with `"`, which is not a formula
+        // lead — but an array starts with `[`, also safe. The risk is when
+        // detectorSummary serializes to something starting with `=`/`@`/etc.,
+        // which can't happen via JSON.stringify of an object/array. We still
+        // assert the wrapping behavior is unchanged for non-formula objects.
+        reasons: ['ok'],
+        tags: ['prod'],
+        detectorSummary: { pii: 0 },
+      },
+    ]);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    const body = await readStream(res);
+    expect(body).toContain('"[""ok""]"');
+    expect(body).toContain('"[""prod""]"');
+    expect(body).toContain('"{""pii"":0}"');
+  });
+
+  it('does not prefix safe leading characters (alphanumerics, quotes)', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce([
+      {
+        id: 'dec-1',
+        ts: new Date('2026-03-01T00:00:00.000Z'),
+        orgId: 'org-1',
+        decision: 'allow',
+        direction: 'ingress',
+        tool: 'safe-tool',
+        scope: '123',
+        policyId: 'p',
+        correlationId: 'corr-1',
+        latencyMs: 1,
+        payloadHash: 'h',
+        reasons: null,
+        tags: [],
+        detectorSummary: {},
+      },
+    ]);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    const body = await readStream(res);
+    const cells = body.trim().split('\n')[1].split(',');
+    expect(cells[5]).toBe('safe-tool');
+    expect(cells[6]).toBe('123');
+    expect(cells[8]).toBe('corr-1');
+  });
+
   it('escapes values containing commas, quotes, and newlines per RFC 4180', async () => {
     mockPrisma.decision.findMany.mockResolvedValueOnce([
       {

--- a/apps/platform/__tests__/api/audit-export.test.ts
+++ b/apps/platform/__tests__/api/audit-export.test.ts
@@ -1,0 +1,369 @@
+/**
+ * TEST-2.2b-api — Dashboard audit log CSV export (GOV-602).
+ *
+ * Covers:
+ *  - 401 when unauthenticated
+ *  - 403 when authenticated role is below ADMIN
+ *  - CSV headers and row format
+ *  - same filter params as /api/v1/audit (decision, tool, user, from, to)
+ *  - orgId is always sourced from the authenticated context
+ *  - validation: invalid decision, invalid format, inverted time range
+ *  - integration: exported rows match the filtered Prisma response
+ *  - streaming: 10k+ rows do not buffer — findMany is paged with a cursor
+ *  - CSV escaping: commas, quotes, newlines, and JSON columns are quoted
+ *  - Content-Type / Content-Disposition response headers
+ */
+
+import { NextRequest } from 'next/server';
+import { prisma } from '@governs-ai/db';
+
+jest.mock('@/lib/session', () => ({
+  requireAuth: jest.fn(),
+  requireRole: jest.fn(),
+}));
+
+import { requireRole } from '@/lib/session';
+import { GET } from '@/app/api/v1/audit/export/route';
+
+const mockRole = requireRole as jest.Mock;
+const mockPrisma = prisma as any;
+
+const AUTH_CTX = {
+  orgId: 'org-1',
+  userId: 'user-1',
+  roles: ['ADMIN'],
+  orgSlug: 'org',
+  session: {},
+};
+
+function makeReq(url: string) {
+  return new NextRequest(url, { method: 'GET' });
+}
+
+async function readStream(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+const CSV_HEADER_LINE =
+  'id,ts,orgId,decision,direction,tool,scope,policyId,correlationId,latencyMs,payloadHash,reasons,tags,detectorSummary';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRole.mockResolvedValue(AUTH_CTX);
+  mockPrisma.decision.findMany.mockResolvedValue([]);
+});
+
+describe('GET /api/v1/audit/export — auth & role', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockRole.mockRejectedValueOnce(new Error('Authentication required'));
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when authenticated user lacks required role', async () => {
+    mockRole.mockRejectedValueOnce(new Error('Role ADMIN required'));
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    expect(res.status).toBe(403);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('enforces ADMIN as the minimum role', async () => {
+    await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    expect(mockRole).toHaveBeenCalledWith(expect.anything(), 'ADMIN');
+  });
+
+  it('always scopes to the authenticated orgId, ignoring any query-string orgId', async () => {
+    await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv&orgId=other-org'),
+    );
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.orgId).toBe('org-1');
+  });
+});
+
+describe('GET /api/v1/audit/export — CSV output format', () => {
+  it('emits a CSV header row with the expected columns', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8');
+    expect(res.headers.get('Content-Disposition')).toMatch(
+      /^attachment; filename="audit-export-.+\.csv"$/,
+    );
+
+    const body = await readStream(res);
+    const [header] = body.split('\n');
+    expect(header).toBe(CSV_HEADER_LINE);
+  });
+
+  it('writes one CSV row per decision with correct column order', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce([
+      {
+        id: 'dec-1',
+        ts: new Date('2026-03-01T12:00:00.000Z'),
+        orgId: 'org-1',
+        decision: 'allow',
+        direction: 'ingress',
+        tool: 'search_web',
+        scope: 'read',
+        policyId: 'pol-1',
+        correlationId: 'corr-1',
+        latencyMs: 42,
+        payloadHash: 'hash-1',
+        reasons: ['ok'],
+        tags: ['prod'],
+        detectorSummary: { pii: 0 },
+      },
+    ]);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    const body = await readStream(res);
+    const lines = body.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      [
+        'dec-1',
+        '2026-03-01T12:00:00.000Z',
+        'org-1',
+        'allow',
+        'ingress',
+        'search_web',
+        'read',
+        'pol-1',
+        'corr-1',
+        '42',
+        'hash-1',
+        '"[""ok""]"',
+        '"[""prod""]"',
+        '"{""pii"":0}"',
+      ].join(','),
+    );
+  });
+
+  it('escapes values containing commas, quotes, and newlines per RFC 4180', async () => {
+    mockPrisma.decision.findMany.mockResolvedValueOnce([
+      {
+        id: 'dec-x',
+        ts: new Date('2026-03-01T00:00:00.000Z'),
+        orgId: 'org-1',
+        decision: 'deny',
+        direction: 'egress',
+        tool: 'a,b',
+        scope: 'he said "hi"',
+        policyId: null,
+        correlationId: 'line1\nline2',
+        latencyMs: null,
+        payloadHash: 'h',
+        reasons: null,
+        tags: [],
+        detectorSummary: {},
+      },
+    ]);
+
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export?format=csv'));
+    const body = await readStream(res);
+    expect(body).toContain('"a,b"');
+    expect(body).toContain('"he said ""hi"""');
+    expect(body).toContain('"line1\nline2"');
+    // null values render as empty fields (policyId, then correlationId quoted, then latencyMs)
+    expect(body).toContain(',"he said ""hi""",,"line1\nline2",,h,,');
+  });
+});
+
+describe('GET /api/v1/audit/export — filters', () => {
+  it('filters by decision, tool, and user (mapped to correlationId)', async () => {
+    await GET(
+      makeReq(
+        'http://localhost/api/v1/audit/export?format=csv&decision=deny&tool=search_web&user=corr-abc',
+      ),
+    );
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.decision).toBe('deny');
+    expect(where.tool).toBe('search_web');
+    expect(where.correlationId).toBe('corr-abc');
+  });
+
+  it('passes `from`/`to` to Prisma as gte/lte bounds on ts', async () => {
+    const from = '2026-01-01T00:00:00.000Z';
+    const to = '2026-01-31T23:59:59.000Z';
+    await GET(
+      makeReq(`http://localhost/api/v1/audit/export?format=csv&from=${from}&to=${to}`),
+    );
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.ts.gte.toISOString()).toBe(from);
+    expect(where.ts.lte.toISOString()).toBe(to);
+  });
+
+  it('ignores malformed date values (treats them as absent)', async () => {
+    await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv&from=not-a-date'),
+    );
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.ts).toBeUndefined();
+  });
+
+  it('rejects an invalid decision value with 400', async () => {
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv&decision=maybe'),
+    );
+    expect(res.status).toBe(400);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid format value with 400', async () => {
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=xlsx'),
+    );
+    expect(res.status).toBe(400);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+
+  it('defaults format to csv when omitted', async () => {
+    const res = await GET(makeReq('http://localhost/api/v1/audit/export'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8');
+  });
+
+  it('returns 400 when `from` is after `to`', async () => {
+    const res = await GET(
+      makeReq(
+        'http://localhost/api/v1/audit/export?format=csv&from=2026-02-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z',
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(mockPrisma.decision.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/audit/export — integration: filtered results match Prisma response', () => {
+  it('exports exactly the rows Prisma returns for the filter', async () => {
+    const dbRows = [
+      {
+        id: 'a',
+        orgId: 'org-1',
+        decision: 'allow',
+        direction: 'ingress',
+        tool: 'x',
+        scope: null,
+        policyId: null,
+        correlationId: null,
+        latencyMs: 1,
+        payloadHash: 'h',
+        reasons: null,
+        tags: [],
+        detectorSummary: {},
+        ts: new Date('2026-03-01'),
+      },
+      {
+        id: 'b',
+        orgId: 'org-1',
+        decision: 'allow',
+        direction: 'ingress',
+        tool: 'y',
+        scope: null,
+        policyId: null,
+        correlationId: null,
+        latencyMs: 2,
+        payloadHash: 'h',
+        reasons: null,
+        tags: [],
+        detectorSummary: {},
+        ts: new Date('2026-03-02'),
+      },
+    ];
+    mockPrisma.decision.findMany.mockResolvedValueOnce(dbRows);
+
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv&decision=allow'),
+    );
+    const body = await readStream(res);
+    const lines = body.trim().split('\n');
+    expect(lines).toHaveLength(dbRows.length + 1);
+    expect(lines[1].startsWith('a,')).toBe(true);
+    expect(lines[2].startsWith('b,')).toBe(true);
+
+    const where = mockPrisma.decision.findMany.mock.calls[0][0].where;
+    expect(where.decision).toBe('allow');
+    expect(where.orgId).toBe('org-1');
+  });
+});
+
+describe('GET /api/v1/audit/export — streaming large exports', () => {
+  function makeRow(i: number) {
+    return {
+      id: `r${String(i).padStart(6, '0')}`,
+      ts: new Date(2026, 0, 1, 0, 0, i),
+      orgId: 'org-1',
+      decision: 'allow',
+      direction: 'ingress',
+      tool: 't',
+      scope: null,
+      policyId: null,
+      correlationId: null,
+      latencyMs: 0,
+      payloadHash: 'h',
+      reasons: null,
+      tags: [],
+      detectorSummary: {},
+    };
+  }
+
+  it('pages Prisma with a cursor instead of a single large take for 10k+ rows', async () => {
+    const TOTAL = 10_000;
+    let yielded = 0;
+
+    mockPrisma.decision.findMany.mockImplementation(async (args: any) => {
+      const take = args.take as number;
+      if (yielded >= TOTAL) return [];
+      const remaining = TOTAL - yielded;
+      const pageSize = Math.min(take, remaining);
+      const batch = Array.from({ length: pageSize }, (_, i) => makeRow(yielded + i));
+      yielded += pageSize;
+      return batch;
+    });
+
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv'),
+    );
+    const body = await readStream(res);
+
+    const lines = body.split('\n').filter(Boolean);
+    // header + 10k rows
+    expect(lines).toHaveLength(TOTAL + 1);
+
+    // Must have paged, not pulled everything at once.
+    const calls = mockPrisma.decision.findMany.mock.calls;
+    expect(calls.length).toBeGreaterThan(1);
+    for (const [args] of calls) {
+      expect(args.take).toBeLessThanOrEqual(1000);
+    }
+    // Every call after the first must use a cursor.
+    for (let i = 1; i < calls.length; i++) {
+      expect(calls[i][0].cursor).toBeDefined();
+      expect(calls[i][0].skip).toBe(1);
+    }
+  });
+
+  it('stops paging when a short page is returned', async () => {
+    mockPrisma.decision.findMany
+      .mockResolvedValueOnce(Array.from({ length: 500 }, (_, i) => makeRow(i)))
+      .mockResolvedValueOnce(Array.from({ length: 3 }, (_, i) => makeRow(500 + i)));
+
+    const res = await GET(
+      makeReq('http://localhost/api/v1/audit/export?format=csv'),
+    );
+    const body = await readStream(res);
+    const lines = body.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(503 + 1);
+    expect(mockPrisma.decision.findMany).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/platform/app/api/v1/audit/export/route.ts
+++ b/apps/platform/app/api/v1/audit/export/route.ts
@@ -138,7 +138,15 @@ export async function GET(request: NextRequest) {
         }
         controller.close();
       } catch (err) {
-        controller.error(err);
+        // Headers are already sent by the time the stream errors, so we
+        // can't return a JSON 500. Log server-side and close cleanly so
+        // Next.js does not emit raw error text into the partial response.
+        console.error('audit export stream failed', { orgId, err });
+        try {
+          controller.close();
+        } catch {
+          // controller may already be in an errored state — swallow.
+        }
       }
     },
   });

--- a/apps/platform/app/api/v1/audit/export/route.ts
+++ b/apps/platform/app/api/v1/audit/export/route.ts
@@ -30,6 +30,11 @@ function parseDateParam(raw: string | null): Date | undefined {
   return Number.isNaN(d.getTime()) ? undefined : d;
 }
 
+// CWE-1236: spreadsheet formula injection. Excel/LibreOffice/Sheets evaluate
+// any cell whose first character is `=`, `+`, `-`, `@`, or a tab as a formula.
+// Prefixing with a literal tab forces the engine to treat the cell as text.
+const FORMULA_LEAD = /^[=+\-@\t]/;
+
 function csvEscape(value: unknown): string {
   if (value === null || value === undefined) return '';
   let s: string;
@@ -39,6 +44,9 @@ function csvEscape(value: unknown): string {
     s = JSON.stringify(value);
   } else {
     s = String(value);
+  }
+  if (FORMULA_LEAD.test(s)) {
+    s = `\t${s}`;
   }
   if (/[",\r\n]/.test(s)) {
     return `"${s.replace(/"/g, '""')}"`;

--- a/apps/platform/app/api/v1/audit/export/route.ts
+++ b/apps/platform/app/api/v1/audit/export/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@governs-ai/db';
+import { requireRole } from '@/lib/session';
+
+const ALLOWED_DECISIONS = ['allow', 'transform', 'deny'] as const;
+const ALLOWED_FORMATS = ['csv'] as const;
+const CHUNK_SIZE = 500;
+const EXPORT_ROLE = 'ADMIN';
+
+const CSV_HEADERS = [
+  'id',
+  'ts',
+  'orgId',
+  'decision',
+  'direction',
+  'tool',
+  'scope',
+  'policyId',
+  'correlationId',
+  'latencyMs',
+  'payloadHash',
+  'reasons',
+  'tags',
+  'detectorSummary',
+] as const;
+
+function parseDateParam(raw: string | null): Date | undefined {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  let s: string;
+  if (value instanceof Date) {
+    s = value.toISOString();
+  } else if (typeof value === 'object') {
+    s = JSON.stringify(value);
+  } else {
+    s = String(value);
+  }
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function rowToCsv(row: Record<string, unknown>): string {
+  return CSV_HEADERS.map((h) => csvEscape(row[h])).join(',') + '\n';
+}
+
+export async function GET(request: NextRequest) {
+  let orgId: string;
+  try {
+    ({ orgId } = await requireRole(request, EXPORT_ROLE));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '';
+    if (msg.startsWith('Role ')) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+
+  const format = (searchParams.get('format') ?? 'csv').toLowerCase();
+  if (!ALLOWED_FORMATS.includes(format as (typeof ALLOWED_FORMATS)[number])) {
+    return NextResponse.json(
+      { error: `Unsupported format. Allowed: ${ALLOWED_FORMATS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  const decision = searchParams.get('decision');
+  const tool = searchParams.get('tool');
+  const user = searchParams.get('user');
+  const from = parseDateParam(searchParams.get('from'));
+  const to = parseDateParam(searchParams.get('to'));
+
+  if (decision && !ALLOWED_DECISIONS.includes(decision as (typeof ALLOWED_DECISIONS)[number])) {
+    return NextResponse.json(
+      { error: `Invalid decision filter. Allowed: ${ALLOWED_DECISIONS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  if (from && to && from > to) {
+    return NextResponse.json(
+      { error: '`from` must be earlier than `to`' },
+      { status: 400 },
+    );
+  }
+
+  const where: Record<string, unknown> = { orgId };
+  if (decision) where.decision = decision;
+  if (tool) where.tool = tool;
+  if (user) where.correlationId = user;
+  if (from || to) {
+    const ts: Record<string, Date> = {};
+    if (from) ts.gte = from;
+    if (to) ts.lte = to;
+    where.ts = ts;
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        controller.enqueue(encoder.encode(CSV_HEADERS.join(',') + '\n'));
+
+        let cursor: { id: string } | undefined;
+        // Cursor pagination on the unique `id` keeps memory bounded at CHUNK_SIZE
+        // rows per iteration, even for exports of hundreds of thousands of rows.
+        while (true) {
+          const rows: Array<Record<string, unknown> & { id: string }> =
+            await prisma.decision.findMany({
+              where,
+              orderBy: [{ ts: 'desc' }, { id: 'desc' }],
+              take: CHUNK_SIZE,
+              ...(cursor ? { cursor, skip: 1 } : {}),
+            });
+          if (rows.length === 0) break;
+          for (const row of rows) {
+            controller.enqueue(encoder.encode(rowToCsv(row)));
+          }
+          if (rows.length < CHUNK_SIZE) break;
+          cursor = { id: rows[rows.length - 1].id };
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+
+  const filename = `audit-export-${new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')}.csv`;
+
+  return new NextResponse(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/audit/export?format=csv` — the backend half of TASKS.md §2.2b. Same filter params as `GET /api/v1/audit` (GOV-586), but returns a streamed `text/csv` body.

## GovernsAI Tracker issue

GOV-602

## Endpoint contract (for Quill → GOV-587 UI wire-up)

- **URL:** `GET /api/v1/audit/export`
- **Query params (all optional, identical to `/api/v1/audit`):**
  - `format` — only `csv` supported today; omitted defaults to csv; anything else → 400
  - `decision` — one of `allow|transform|deny`
  - `tool` — exact match
  - `user` — maps to `correlationId` (same mapping as GOV-586; swap to `userId` when Decision gets that column)
  - `from`, `to` — ISO-8601; `from > to` → 400; malformed dates silently ignored
- **Auth:** `requireRole(ADMIN)` — 401 unauthenticated, 403 below ADMIN
- **Response headers:**
  - `Content-Type: text/csv; charset=utf-8`
  - `Content-Disposition: attachment; filename="audit-export-<iso-ts>.csv"`
  - `Cache-Control: no-store`
- **CSV columns:** `id, ts, orgId, decision, direction, tool, scope, policyId, correlationId, latencyMs, payloadHash, reasons, tags, detectorSummary`
- **Escaping:** RFC 4180 — fields containing `,`, `"`, `\r`, or `\n` are quoted with internal `"` doubled; `Date` → ISO-8601; objects → JSON.

## Why role-gate at ADMIN?

Cipher's non-blocking note on GOV-586 flagged that the sidebar restricts the audit log to OWNER/ADMIN while `/api/v1/audit` has no role check. A compliance-grade CSV export is the most sensitive surface of that pipeline, so this endpoint enforces ADMIN at the route level. A DEVELOPER-role member can no longer exfiltrate the full decision log as CSV. Harmonizing `/api/v1/audit` itself can be a separate follow-up.

## Streaming / memory

`ReadableStream<Uint8Array>` body. Rows are pulled from Prisma in 500-row batches using cursor pagination (`orderBy: [{ ts: 'desc' }, { id: 'desc' }]`, `cursor: { id }, skip: 1`). A 10k+ row export never buffers more than one batch in memory — enforced by test.

## Reviewers

Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan

- [x] Auth: 401 unauthenticated / 403 below ADMIN / orgId always sourced from session
- [x] CSV: header line + column order + RFC 4180 escaping (comma, quote, newline, null)
- [x] Filters: `decision`, `tool`, `user→correlationId`, `from/to → gte/lte` on `ts`
- [x] Validation: invalid `decision`, invalid `format`, inverted time range → 400; malformed date silently ignored
- [x] Integration: exported rows exactly match Prisma filter response
- [x] Streaming: 10k rows → multiple `findMany` calls, bounded `take`, cursor-based paging
- [x] Response headers: `Content-Type`, `Content-Disposition`, attachment filename format
- [x] `apps/platform` jest suite — 92/92 pass; `tsc --noEmit` clean

## Out of scope

- No `xlsx`/`json` formats (would bloat scope; `format=` param already wired so they slot in later)
- Harmonizing ADMIN role gate on the existing `/api/v1/audit` — intentional follow-up