### PR TITLE
ci: remove redundant Vercel preview deploy job (GOV-2267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,63 +103,11 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ci_db
 
-  deploy:
-    name: Deploy to Vercel (Preview)
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    outputs:
-      url: ${{ steps.deploy_step.outputs.url }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel@latest
-
-      - name: Pull Vercel Environment
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Vercel Output
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel
-        id: deploy_step
-        run: |
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)
-          echo "url=$url" >> $GITHUB_OUTPUT
-
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: deploy
-    env:
-      PLAYWRIGHT_BASE_URL: ${{ needs.deploy.outputs.url }}
-      TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
-      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-      E2E_TEST_ORG_SLUG: ${{ vars.E2E_TEST_ORG_SLUG }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Install Playwright Browsers
-        run: pnpm --filter @governs-ai/platform exec playwright install --with-deps chromium
-      - name: Run E2E Tests
-        run: pnpm --filter @governs-ai/platform test:e2e
-      - name: Upload Playwright report on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: |
-            apps/platform/playwright-report
-            apps/platform/test-results
-          retention-days: 7
+  # Preview deploys are produced by the native Vercel GitHub integration
+  # (the `Vercel` check on each PR). The previous `deploy` job here ran
+  # `vercel pull/build/deploy` with no VERCEL_TOKEN secret configured and
+  # failed on every PR — see GOV-2267.
+  #
+  # The dependent `e2e-tests` job has been removed alongside `deploy` because
+  # it was always skipped. E2E will be reinstated under task 2.5 with preview
+  # URL acquired from the native Vercel deployment_status event.


### PR DESCRIPTION
## Summary

- Remove the workflow-driven `deploy` job from `.github/workflows/ci.yml`. It ran `vercel pull/build/deploy` with an empty `VERCEL_TOKEN` secret and failed on every PR (red `Deploy to Vercel (Preview)` check).
- Remove the dependent `e2e-tests` job. It always reported `skipped` because `deploy` failed first, so no real E2E coverage is being lost — E2E will be reinstated under task 2.5 with the preview URL pulled from the native Vercel `deployment_status` event.

## Why option 2 (delete) over option 1 (provision the token)

The native Vercel GitHub integration is already wired up — the green `Vercel` check on every PR is the authoritative preview deploy. The workflow `deploy` job is a duplicate path that does no useful work. Removing it eliminates the redundant noise without losing any deploy coverage. (Per recommendation in [GOV-2267](mention://issue/ca5a5801-5c56-4c92-91e7-c107d93e58a5).)

## GovernsAI Tracker issue

[GOV-2267](mention://issue/ca5a5801-5c56-4c92-91e7-c107d93e58a5)

## Evidence the secrets are unset

```
$ gh secret list --repo Governs-AI/governsai-console
E2E_PASSWORD, E2E_USERNAME, KEYCLOAK_CHAT_CLIENT_SECRET, NEXTAUTH_SECRET,
STAGING_CHAT_URL, STAGING_KEYCLOAK_URL, STAGING_PLATFORM_URL, STAGING_PRECHECK_URL
```

No `VERCEL_TOKEN`, `VERCEL_ORG_ID`, or `VERCEL_PROJECT_ID`.

## Reviewers

Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required per SDLC rules.

## Test plan

- [ ] CI on this PR is green (only `lint-and-typecheck`, `unit-test`, `build` remain).
- [ ] The native `Vercel` preview check still appears and passes.
- [ ] Confirm no other workflow file or branch protection rule references the removed `deploy` / `e2e-tests` job names.

## Follow-up

Forge to reinstate E2E in CI under task 2.5 using `wait-for-vercel-preview` (or the deployment_status event pattern) so Playwright runs against the native preview without needing self-managed deploy credentials.